### PR TITLE
remove masking_algorithm field from CRD

### DIFF
--- a/api/v1alpha1/fivetranconnector_types.go
+++ b/api/v1alpha1/fivetranconnector_types.go
@@ -131,9 +131,6 @@ type ColumnObject struct {
 	Enabled      bool `json:"enabled"`
 	Hashed       bool `json:"hashed,omitempty"`
 	IsPrimaryKey bool `json:"is_primary_key,omitempty"`
-	// +kubebuilder:validation:Enum=PLAINTEXT;HASHED;ENCRYPTED
-	// The masking algorithm to apply to the column data. PLAINTEXT stores data as-is, HASHED applies hashing, ENCRYPTED applies encryption.
-	MaskingAlgorithm string `json:"masking_algorithm,omitempty"`
 }
 
 // FivetranConnectorStatus defines the observed state of FivetranConnector

--- a/config/crd/bases/operator.dataverse.redhat.com_fivetranconnectors.yaml
+++ b/config/crd/bases/operator.dataverse.redhat.com_fivetranconnectors.yaml
@@ -217,16 +217,6 @@ spec:
                                       type: boolean
                                     is_primary_key:
                                       type: boolean
-                                    masking_algorithm:
-                                      description: The masking algorithm to apply
-                                        to the column data. PLAINTEXT stores data
-                                        as-is, HASHED applies hashing, ENCRYPTED applies
-                                        encryption.
-                                      enum:
-                                      - PLAINTEXT
-                                      - HASHED
-                                      - ENCRYPTED
-                                      type: string
                                   required:
                                   - enabled
                                   type: object

--- a/docs/fivetranconnector/fivetranconnector-crd.md
+++ b/docs/fivetranconnector/fivetranconnector-crd.md
@@ -98,15 +98,6 @@ Each key in the `schemas` map represents a schema name, with the value being a s
 | `enabled` | boolean | **Yes** | Whether this column should be synchronized |
 | `hashed` | boolean | **Yes** | Whether the column data should be hashed |
 | `is_primary_key` | boolean | **Yes** | Whether this column is part of the primary key |
-| `masking_algorithm` | string | No | The masking algorithm to apply to column data |
-
-**Column `masking_algorithm` Values:**
-
-| Value | Description |
-|-------|-------------|
-| `PLAINTEXT` | Stores data as-is without any masking |
-| `HASHED` | Applies hashing to the column data |
-| `ENCRYPTED` | Applies encryption to the column data |
 
 ---
 


### PR DESCRIPTION
Drops the masking_algorithm field from the ColumnObject schema because:
- The masking_algorithm was dropped from [Fivetran OpenAPI Spec](https://fivetran.com/docs/rest-api/api-reference/open-api-definition) 