### PR TITLE
fix: SchemaBuilder.AddColumn overwrites table config, dropping enabled and sync_mode

### DIFF
--- a/pkg/fivetran/schema_builder.go
+++ b/pkg/fivetran/schema_builder.go
@@ -10,6 +10,7 @@ import (
 // SchemaBuilder provides a fluent interface for building schema configurations
 type SchemaBuilder struct {
 	schemas              map[string]*connections.ConnectionSchemaConfigSchema
+	tables               map[string]map[string]*connections.ConnectionSchemaConfigTable
 	schemaChangeHandling string
 	err                  error
 }
@@ -18,6 +19,7 @@ type SchemaBuilder struct {
 func NewSchemaBuilder() *SchemaBuilder {
 	return &SchemaBuilder{
 		schemas: make(map[string]*connections.ConnectionSchemaConfigSchema),
+		tables:  make(map[string]map[string]*connections.ConnectionSchemaConfigTable),
 	}
 }
 
@@ -66,6 +68,11 @@ func (b *SchemaBuilder) AddTable(schema, table string, enabled bool, syncMode st
 		tableConfig.SyncMode(syncMode)
 	}
 	s.Table(table, tableConfig)
+
+	if b.tables[schema] == nil {
+		b.tables[schema] = make(map[string]*connections.ConnectionSchemaConfigTable)
+	}
+	b.tables[schema][table] = tableConfig
 	return b
 }
 
@@ -79,9 +86,9 @@ func (b *SchemaBuilder) AddColumn(schema, table, column string, enabled, hashed,
 		return b
 	}
 
-	s, ok := b.schemas[schema]
+	tableConfig, ok := b.tables[schema][table]
 	if !ok {
-		b.err = fmt.Errorf("schema %q not found", schema)
+		b.err = fmt.Errorf("table %q not found in schema %q", table, schema)
 		return b
 	}
 
@@ -94,8 +101,6 @@ func (b *SchemaBuilder) AddColumn(schema, table, column string, enabled, hashed,
 		columnConfig.IsPrimaryKey(isPrimaryKey)
 	}
 
-	tableConfig := &connections.ConnectionSchemaConfigTable{}
-	s.Table(table, tableConfig)
 	tableConfig.Column(column, columnConfig)
 
 	return b

--- a/pkg/fivetran/schema_builder_test.go
+++ b/pkg/fivetran/schema_builder_test.go
@@ -1,0 +1,114 @@
+package fivetran
+
+import (
+	"testing"
+)
+
+func TestAddColumn_OverwritesTableConfig(t *testing.T) {
+	builder := NewSchemaBuilder()
+	builder.AddSchema("myschema", true)
+	builder.AddTable("myschema", "mytable", true, "SOFT_DELETE")
+	builder.AddColumn("myschema", "mytable", "mycol", true, false, false)
+
+	schemas, _, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build() returned unexpected error: %v", err)
+	}
+
+	schema, ok := schemas["myschema"]
+	if !ok {
+		t.Fatal("schema 'myschema' not found in build output")
+	}
+
+	tableReq := schema.Request().Tables["mytable"]
+	if tableReq == nil {
+		t.Fatal("table 'mytable' not found in schema request")
+	}
+
+	// Verify table enabled state survived AddColumn
+	if tableReq.Enabled == nil {
+		t.Fatal("table Enabled is nil — AddColumn overwrote the table config created by AddTable")
+	}
+	if !*tableReq.Enabled {
+		t.Errorf("table Enabled = false, want true")
+	}
+
+	// Verify table sync mode survived AddColumn
+	if tableReq.SyncMode == nil {
+		t.Fatal("table SyncMode is nil — AddColumn overwrote the table config created by AddTable")
+	}
+	if *tableReq.SyncMode != "SOFT_DELETE" {
+		t.Errorf("table SyncMode = %q, want %q", *tableReq.SyncMode, "SOFT_DELETE")
+	}
+
+	// Verify the column was still added
+	if tableReq.Columns == nil || tableReq.Columns["mycol"] == nil {
+		t.Fatal("column 'mycol' not found — column was not added")
+	}
+}
+
+func TestAddMultipleColumns_OverwritesTableConfig(t *testing.T) {
+	builder := NewSchemaBuilder()
+	builder.AddSchema("myschema", true)
+	builder.AddTable("myschema", "mytable", false, "HISTORY")
+	builder.AddColumn("myschema", "mytable", "col_a", true, true, false)
+	builder.AddColumn("myschema", "mytable", "col_b", false, false, true)
+
+	schemas, _, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build() returned unexpected error: %v", err)
+	}
+
+	tableReq := schemas["myschema"].Request().Tables["mytable"]
+	if tableReq == nil {
+		t.Fatal("table 'mytable' not found")
+	}
+
+	// Table settings should be preserved from AddTable
+	if tableReq.Enabled == nil {
+		t.Fatal("table Enabled is nil after multiple AddColumn calls")
+	}
+	if *tableReq.Enabled != false {
+		t.Errorf("table Enabled = %v, want false", *tableReq.Enabled)
+	}
+	if tableReq.SyncMode == nil {
+		t.Fatal("table SyncMode is nil after multiple AddColumn calls")
+	}
+	if *tableReq.SyncMode != "HISTORY" {
+		t.Errorf("table SyncMode = %q, want %q", *tableReq.SyncMode, "HISTORY")
+	}
+
+	// Both columns should be present
+	if tableReq.Columns == nil {
+		t.Fatal("columns map is nil")
+	}
+	if tableReq.Columns["col_a"] == nil {
+		t.Error("column 'col_a' missing")
+	}
+	if tableReq.Columns["col_b"] == nil {
+		t.Error("column 'col_b' missing")
+	}
+}
+
+func TestAddTable_WithoutColumns_PreservesConfig(t *testing.T) {
+	builder := NewSchemaBuilder()
+	builder.AddSchema("myschema", true)
+	builder.AddTable("myschema", "mytable", true, "LIVE")
+
+	schemas, _, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build() returned unexpected error: %v", err)
+	}
+
+	tableReq := schemas["myschema"].Request().Tables["mytable"]
+	if tableReq == nil {
+		t.Fatal("table 'mytable' not found")
+	}
+
+	if tableReq.Enabled == nil || !*tableReq.Enabled {
+		t.Errorf("table Enabled = %v, want true", tableReq.Enabled)
+	}
+	if tableReq.SyncMode == nil || *tableReq.SyncMode != "LIVE" {
+		t.Errorf("table SyncMode = %v, want LIVE", tableReq.SyncMode)
+	}
+}


### PR DESCRIPTION
## Summary

`SchemaBuilder.AddColumn()` was creating a new empty `ConnectionSchemaConfigTable` and replacing the existing one in the schema's table map. This silently dropped the `enabled` and `sync_mode` values that were previously set by `AddTable()`.

Any connector with column-level configuration in its CR had its table-level settings (`enabled`, `sync_mode`) stripped from the API payload sent to Fivetran.

## Root Cause

The Fivetran SDK's `ConnectionSchemaConfigSchema.Table(name, table)` method does a map assignment (`css.tables[name] = table`), replacing any existing entry. The old `AddColumn` code was calling this with a brand new empty table config:

```go
// Before (bug)
tableConfig := &connections.ConnectionSchemaConfigTable{}  // new empty config
s.Table(table, tableConfig)                                 // overwrites existing
tableConfig.Column(column, columnConfig)
```

## Fix

Track table configs in a local map within `SchemaBuilder`. `AddColumn` now looks up the existing table config instead of creating a new one:

```go
// After (fix)
tableConfig, ok := b.tables[schema][table]  // reuse existing config
if !ok {
    b.err = fmt.Errorf("table %q not found in schema %q", table, schema)
    return b
}
tableConfig.Column(column, columnConfig)
```

## Impact Example

For a CR with:
```yaml
tables:
  sometable:
    enabled: true
    sync_mode: HISTORY
    columns:
      somecolumn:
        enabled: false
```

**Before (bug)** — payload sent to Fivetran API:
```json
"sometable": {
  "columns": {
    "somecolumn": { "enabled": false }
  }
}
```
`enabled` and `sync_mode` are missing. After a `reloadSchema` (which defaults to `SOFT_DELETE`), the PATCH doesn't correct it, causing:
```
sync mode mismatch: expected HISTORY, got SOFT_DELETE
schema still mismatches CR after retry; possible schema config issue
```

**After (fix)** — payload sent to Fivetran API:
```json
"sometable": {
  "enabled": true,
  "sync_mode": "HISTORY",
  "columns": {
    "somecolumn": { "enabled": false }
  }
}
```

## Connectors affected

Only connectors that define `columns` in their schema config. Connectors with only table-level config (no columns) were never impacted.

## Test plan

- [x] Unit test added: `TestAddColumn_OverwritesTableConfig` — verifies `enabled` and `sync_mode` survive `AddColumn`
- [x] Unit test added: `TestAddMultipleColumns_OverwritesTableConfig` — verifies multiple columns preserve table config
- [x] All existing schema comparison tests pass
```