### PR TITLE
fix: resolve schema apply 500 error with granular condition retries and sync-state guard

### DIFF
--- a/internal/controller/fivetranconnector/constants.go
+++ b/internal/controller/fivetranconnector/constants.go
@@ -79,4 +79,5 @@ var (
 	ErrSchemaMismatchAfterRetry        = errors.New("schema still mismatches CR after retry; possible schema config issue")
 	ErrSetupTestsFailed                = errors.New("setup tests failed")
 	ErrConnectorValidationFailed       = errors.New("connector validation failed from annotation")
+	ErrConnectorSyncing                = errors.New("connector is currently syncing, will retry after sync completes")
 )

--- a/internal/controller/fivetranconnector/controller.go
+++ b/internal/controller/fivetranconnector/controller.go
@@ -93,8 +93,14 @@ func (r *FivetranConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return r.handleError(ctx, connector, conditionTypeConnectorReady, ConnectorReasonFinalizerUpdateFailed, err)
 	}
 
-	// Check force reconcile flag
+	// Check force reconcile flag and remove it immediately so it's not re-read on requeue
 	forceReconcile := kubeutils.HasLabel(connector, annotationForceReconcile)
+	if forceReconcile {
+		kubeutils.RemoveLabel(connector, annotationForceReconcile)
+		if err := r.Update(ctx, connector); err != nil {
+			return r.handleError(ctx, connector, conditionTypeConnectorReady, ConnectorReasonReconciliationFailed, err)
+		}
+	}
 
 	// Determine what needs to be reconciled
 	reconcileConnector, reconcileSchema, err := r.determineReconciliationNeeds(ctx, connector, forceReconcile)
@@ -143,14 +149,14 @@ func (r *FivetranConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.reconcileSchema(ctx, connector, connectorID); err != nil {
 			return r.handleError(ctx, connector, conditionTypeSchemaReady, SchemaReasonReconciliationFailed, err)
 		}
-	} else {
+	} else if !r.hasSchemaConfig(connector) {
 		if err := r.setCondition(ctx, connector, conditionTypeSchemaReady, metav1.ConditionTrue, SchemaReasonSkipped, msgSchemaSkipped); err != nil {
 			return r.handleError(ctx, connector, conditionTypeSchemaReady, SchemaReasonSkipped, err)
 		}
 	}
 
-	// Update connector again to set ScheduleType and pause state
-	// This is needed because ScheduleType is not available in createconnector API
+	// Update connector again to set ScheduleType and pause state.
+	// This is needed because ScheduleType is not available in the create API.
 	if reconcileConnector {
 		logger.Info("Updating connector again to set ScheduleType and pause state")
 		if err := r.updateConnector(ctx, connector, connectorID, resolvedConfig, resolvedAuth); err != nil {

--- a/internal/controller/fivetranconnector/schema_ops.go
+++ b/internal/controller/fivetranconnector/schema_ops.go
@@ -36,11 +36,31 @@ func getValidationLevel(connector *operatorv1alpha1.FivetranConnector) string {
 	return connector.Spec.ConnectorSchemas.ValidationLevel
 }
 
+// isConnectorSyncing checks if the connector is actively syncing
+func (r *FivetranConnectorReconciler) isConnectorSyncing(ctx context.Context, connectorID string) (bool, error) {
+	resp, err := r.FivetranClient.Connections.GetConnection(ctx, connectorID)
+	if err != nil {
+		return false, fmt.Errorf("isConnectorSyncing: %w", err)
+	}
+	syncState := resp.Data.Status.SyncState
+	log.FromContext(ctx).Info("Checked connector sync state", "syncState", syncState)
+	return syncState == "syncing", nil
+}
+
 // reconcileSchema configures connector schema
 func (r *FivetranConnectorReconciler) reconcileSchema(ctx context.Context, connector *operatorv1alpha1.FivetranConnector, connectorID string) error {
 	logger := log.FromContext(ctx)
 	validationLevel := getValidationLevel(connector)
 	logger.Info("Reconciling schema", "validationLevel", validationLevel)
+
+	// Check if connector is actively syncing before attempting schema changes
+	syncing, err := r.isConnectorSyncing(ctx, connectorID)
+	if err != nil {
+		return fmt.Errorf("reconcileSchema: %w", err)
+	}
+	if syncing {
+		return ErrConnectorSyncing
+	}
 
 	// Get current schema from Fivetran
 	schemaDetails, err := r.FivetranClient.Schemas.GetSchemaDetails(ctx, connectorID)

--- a/internal/controller/fivetranconnector/status_mgmt.go
+++ b/internal/controller/fivetranconnector/status_mgmt.go
@@ -35,6 +35,16 @@ import (
 // handleError handles errors by setting appropriate conditions and updating status
 func (r *FivetranConnectorReconciler) handleError(ctx context.Context, connector *operatorv1alpha1.FivetranConnector, conditionType, reason string, err error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	// Connector is syncing — mark schema as failed so the granular retry picks it up, then requeue
+	if errors.Is(err, ErrConnectorSyncing) {
+		logger.Info("Connector is syncing, requeueing reconcile", "requeueAfter", "2m")
+		if setErr := r.setCondition(ctx, connector, conditionType, metav1.ConditionFalse, reason, err.Error()); setErr != nil {
+			return ctrl.Result{}, setErr
+		}
+		return ctrl.Result{RequeueAfter: 2 * time.Minute}, nil
+	}
+
 	logger.Error(err, "Reconcile failed", "conditionType", conditionType, "reason", reason)
 
 	// Check if the error is a schema configuration error (should not requeue)

--- a/internal/controller/fivetranconnector/utils.go
+++ b/internal/controller/fivetranconnector/utils.go
@@ -87,6 +87,11 @@ func (r *FivetranConnectorReconciler) determineReconciliationNeeds(ctx context.C
 
 	reconcileConnector = connectorHashChanged
 	reconcileSchema = schemaHashChanged
+
+	logger.Info("Reconciliation decision",
+		"reconcileConnector", reconcileConnector, "reconcileSchema", reconcileSchema,
+		"connectorHashChanged", connectorHashChanged, "schemaHashChanged", schemaHashChanged,
+		"hasStatusConnectorID", connector.Status.ConnectorID != "")
 	return reconcileConnector, reconcileSchema, nil
 }
 
@@ -300,6 +305,10 @@ func (*FivetranConnectorReconciler) calculateSchemaHash(connector *operatorv1alp
 
 // hasConnectorHashChanged checks if the connector configuration has changed by comparing hashes
 func (r *FivetranConnectorReconciler) hasConnectorHashChanged(connector *operatorv1alpha1.FivetranConnector) (bool, error) {
+	if connector.Status.ConnectorID == "" {
+		return true, nil
+	}
+
 	currentConnectorHash, err := r.calculateConnectorHash(connector)
 	if err != nil {
 		return false, fmt.Errorf("hasConnectorHashChanged: %w", err)

--- a/internal/controller/fivetranconnector/utils.go
+++ b/internal/controller/fivetranconnector/utils.go
@@ -52,15 +52,25 @@ func (r *FivetranConnectorReconciler) ensureFinalizer(ctx context.Context, conne
 func (r *FivetranConnectorReconciler) determineReconciliationNeeds(ctx context.Context, connector *operatorv1alpha1.FivetranConnector, forceReconcile bool) (reconcileConnector, reconcileSchema bool, err error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Determining reconciliation requirements")
-	// Force reconcile or any failed conditions means reconcile everything
-	if forceReconcile || r.hasFailedConditions(connector) {
-		if forceReconcile {
-			logger.Info("Force reconcile requested, reconciling all components")
-		} else {
-			logger.Info("Previous reconcile failed, retrying all components")
-		}
+
+	if forceReconcile {
+		logger.Info("Force reconcile requested, reconciling all components")
 		reconcileConnector = true
 		reconcileSchema = r.hasSchemaConfig(connector)
+		return reconcileConnector, reconcileSchema, nil
+	}
+
+	// For failed conditions, only re-reconcile the components that actually failed
+	if r.hasFailedConditions(connector) {
+		connectorFailed := r.isConditionFalse(connector, conditionTypeConnectorReady)
+		setupTestFailed := r.isConditionFalse(connector, conditionTypeSetupTestReady)
+		schemaFailed := r.isConditionFalse(connector, conditionTypeSchemaReady)
+
+		reconcileConnector = connectorFailed || setupTestFailed
+		reconcileSchema = schemaFailed
+
+		logger.Info("Previous reconcile had failures, retrying failed components",
+			"reconcileConnector", reconcileConnector, "reconcileSchema", reconcileSchema)
 		return reconcileConnector, reconcileSchema, nil
 	}
 
@@ -147,6 +157,16 @@ func (*FivetranConnectorReconciler) hasFailedConditions(connector *operatorv1alp
 
 	for _, condition := range connector.Status.Conditions {
 		if condition.Status == metav1.ConditionFalse {
+			return true
+		}
+	}
+	return false
+}
+
+// isConditionFalse checks if a specific condition is in a failed state
+func (*FivetranConnectorReconciler) isConditionFalse(connector *operatorv1alpha1.FivetranConnector, conditionType string) bool {
+	for _, c := range connector.Status.Conditions {
+		if c.Type == conditionType && c.Status == metav1.ConditionFalse {
 			return true
 		}
 	}

--- a/internal/controller/fivetranconnector/utils_test.go
+++ b/internal/controller/fivetranconnector/utils_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fivetranconnector
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/redhat-data-and-ai/fivetran-operator/api/v1alpha1"
+)
+
+func connectorWithConditions(conditions ...metav1.Condition) *operatorv1alpha1.FivetranConnector {
+	return &operatorv1alpha1.FivetranConnector{
+		Status: operatorv1alpha1.FivetranConnectorStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func condition(condType string, status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:   condType,
+		Status: status,
+	}
+}
+
+func TestIsConditionFalse_SchemaFailed(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := connectorWithConditions(
+		condition("ConnectorReady", metav1.ConditionTrue),
+		condition("SetupTestReady", metav1.ConditionTrue),
+		condition("SchemaReady", metav1.ConditionFalse),
+	)
+
+	if !r.isConditionFalse(connector, "SchemaReady") {
+		t.Error("expected SchemaReady to be detected as False")
+	}
+	if r.isConditionFalse(connector, "ConnectorReady") {
+		t.Error("expected ConnectorReady to not be False")
+	}
+	if r.isConditionFalse(connector, "SetupTestReady") {
+		t.Error("expected SetupTestReady to not be False")
+	}
+}
+
+func TestIsConditionFalse_ConnectorFailed(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := connectorWithConditions(
+		condition("ConnectorReady", metav1.ConditionFalse),
+	)
+
+	if !r.isConditionFalse(connector, "ConnectorReady") {
+		t.Error("expected ConnectorReady to be detected as False")
+	}
+	if r.isConditionFalse(connector, "SchemaReady") {
+		t.Error("expected SchemaReady to not be False when not present")
+	}
+}
+
+func TestIsConditionFalse_NoConditions(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := &operatorv1alpha1.FivetranConnector{}
+
+	if r.isConditionFalse(connector, "ConnectorReady") {
+		t.Error("expected no false conditions on empty connector")
+	}
+}
+
+func TestIsConditionFalse_AllTrue(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := connectorWithConditions(
+		condition("ConnectorReady", metav1.ConditionTrue),
+		condition("SetupTestReady", metav1.ConditionTrue),
+		condition("SchemaReady", metav1.ConditionTrue),
+	)
+
+	if r.isConditionFalse(connector, "ConnectorReady") {
+		t.Error("expected ConnectorReady to not be False")
+	}
+	if r.isConditionFalse(connector, "SetupTestReady") {
+		t.Error("expected SetupTestReady to not be False")
+	}
+	if r.isConditionFalse(connector, "SchemaReady") {
+		t.Error("expected SchemaReady to not be False")
+	}
+}
+
+func TestIsConditionFalse_SetupTestFailed(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := connectorWithConditions(
+		condition("ConnectorReady", metav1.ConditionTrue),
+		condition("SetupTestReady", metav1.ConditionFalse),
+	)
+
+	if !r.isConditionFalse(connector, "SetupTestReady") {
+		t.Error("expected SetupTestReady to be detected as False")
+	}
+	if r.isConditionFalse(connector, "ConnectorReady") {
+		t.Error("expected ConnectorReady to not be False")
+	}
+}
+
+func TestHasFailedConditions_OnlySchemaFailed(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := connectorWithConditions(
+		condition("ConnectorReady", metav1.ConditionTrue),
+		condition("SetupTestReady", metav1.ConditionTrue),
+		condition("SchemaReady", metav1.ConditionFalse),
+	)
+
+	if !r.hasFailedConditions(connector) {
+		t.Error("expected hasFailedConditions to return true")
+	}
+}
+
+func TestHasFailedConditions_NoneSet(t *testing.T) {
+	r := &FivetranConnectorReconciler{}
+	connector := &operatorv1alpha1.FivetranConnector{}
+
+	if r.hasFailedConditions(connector) {
+		t.Error("expected hasFailedConditions to return false with no conditions")
+	}
+}


### PR DESCRIPTION
## Problem

When a connector reconciliation fails at the schema step (e.g., due to a Fivetran API 500 "Failed to stop in-progress sync after trying for 60 seconds"), every subsequent retry re-runs the **entire** reconciliation — connector update, setup tests, and schema apply — even though only the schema step failed. The connector update and setup tests trigger a new sync, which means the schema apply hits the same 500 error again, creating an infinite failure loop.

Additionally, the `SchemaReady` condition was incorrectly set to "No schema configuration specified" whenever schema reconciliation was skipped due to an unchanged hash, even when schema config was present in the CR.

## Root Cause

1. `determineReconciliationNeeds` treated all failed conditions identically: if **any** condition was `False`, it set `reconcileConnector=true` and `reconcileSchema=true`, regardless of which component actually failed.
2. There was no check for whether the connector was actively syncing before attempting schema changes.
3. The force-reconcile label was only cleaned up at the end of reconciliation, so if schema apply failed mid-reconcile, the label persisted and caused a full re-reconcile on every retry.
4. The `else` branch for schema condition incorrectly set "No schema configuration specified" even when schema config existed but simply hadn't changed.

## Fix

### 1. Granular condition retries (`utils.go`)

- Added `isConditionFalse(connector, conditionType)` helper to check a specific condition.
- Changed `determineReconciliationNeeds` so that when retrying after failed conditions, it only re-runs the components whose conditions actually failed:
  - `ConnectorReady=False` or `SetupTestReady=False` → `reconcileConnector=true`
  - `SchemaReady=False` → `reconcileSchema=true`
  - Force reconcile still reconciles everything.

### 2. Sync-state guard before schema apply (`schema_ops.go`)

- Added `isConnectorSyncing` that calls `GetConnection` and checks `sync_state == "syncing"`.
- `reconcileSchema` now checks this before any schema operations. If syncing, it returns `ErrConnectorSyncing`.
- `handleError` catches `ErrConnectorSyncing`, sets `SchemaReady=False`, and requeues after 2 minutes. The next retry only re-runs schema (not connector/setup tests) thanks to the granular condition logic.

### 3. Early force-reconcile label cleanup (`controller.go`)

- The force-reconcile label is now removed immediately after reading it, before any reconcile work begins. This prevents it from persisting through requeues.

### 4. Schema condition fix (`controller.go`)

- Changed `else` to `else if !r.hasSchemaConfig(connector)` so that "No schema configuration specified" is only set when no schema config exists in the CR. When schema config exists but hasn't changed, the existing `SchemaReady` condition is left untouched.

## Files Changed

- `internal/controller/fivetranconnector/utils.go` — granular `determineReconciliationNeeds`, `isConditionFalse` helper
- `internal/controller/fivetranconnector/schema_ops.go` — `isConnectorSyncing` helper, sync check at top of `reconcileSchema`
- `internal/controller/fivetranconnector/constants.go` — `ErrConnectorSyncing` sentinel error
- `internal/controller/fivetranconnector/status_mgmt.go` — requeue handler for `ErrConnectorSyncing`
- `internal/controller/fivetranconnector/controller.go` — early force-reconcile label cleanup, schema condition fix
- `internal/controller/fivetranconnector/utils_test.go` — unit tests for `isConditionFalse`

## Testing

- Unit tests pass for `isConditionFalse` and `hasFailedConditions`.
- Verified against live Fivetran marketo connector:
  - **Force reconcile when connector syncing**: connector updates and setup tests run, sync-state guard detects syncing, requeues in 2 min. On retry, only schema re-runs (connector skipped), schema applies successfully.
  - **Force reconcile when connector idle**: full reconcile completes in a single pass.
  - **Failed SchemaReady retry**: only schema re-runs, no unnecessary connector update or setup tests.
