### PR TITLE
DATA-6517: Add delete protection for FivetranConnector using annotation

### DIFF
--- a/internal/controller/fivetranconnector/constants.go
+++ b/internal/controller/fivetranconnector/constants.go
@@ -24,6 +24,7 @@ const (
 	fivetranConnectorURL = "https://fivetran.com/dashboard/connectors/%s"
 
 	// Annotation constants
+	annotationAllowDeletion  = "operator.dataverse.redhat.com/allow-deletion"
 	annotationForceReconcile = "operator.dataverse.redhat.com/force-reconcile"
 	annotationConnectorHash  = "operator.dataverse.redhat.com/connector-hash"
 	annotationSchemaHash     = "operator.dataverse.redhat.com/schema-hash"

--- a/internal/controller/fivetranconnector/controller.go
+++ b/internal/controller/fivetranconnector/controller.go
@@ -18,6 +18,7 @@ package fivetranconnector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -173,7 +174,9 @@ func (r *FivetranConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return ctrl.Result{}, nil
 }
 
-// handleDeletion handles connector deletion
+// handleDeletion handles connector deletion.
+// By default, the Fivetran connector is preserved (orphaned) unless the
+// allow-deletion annotation is explicitly set to "true".
 func (r *FivetranConnectorReconciler) handleDeletion(ctx context.Context, connector *operatorv1alpha1.FivetranConnector) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Handling deletion", "connector", connector.Name, "connectorId", connector.Status.ConnectorID)
@@ -183,11 +186,22 @@ func (r *FivetranConnectorReconciler) handleDeletion(ctx context.Context, connec
 	}
 
 	if connector.Status.ConnectorID != "" {
-		_, err := r.FivetranClient.Connections.DeleteConnection(ctx, connector.Status.ConnectorID)
-		if err != nil {
-			return err
+		allowDeletion := kubeutils.GetAnnotation(connector, annotationAllowDeletion) == "true"
+
+		if allowDeletion {
+			_, err := r.FivetranClient.Connections.DeleteConnection(ctx, connector.Status.ConnectorID)
+			if err != nil {
+				return err
+			}
+			logger.Info("Successfully deleted Fivetran connector", "connectorID", connector.Status.ConnectorID)
+		} else {
+			specJSON, _ := json.Marshal(connector.Spec)
+			logger.Info("Orphaning Fivetran connector: allow-deletion annotation not set",
+				"connector", connector.Name,
+				"connectorID", connector.Status.ConnectorID,
+				"spec", string(specJSON),
+				"hint", "To delete both CR and Fivetran connector, annotate: operator.dataverse.redhat.com/allow-deletion=true")
 		}
-		logger.Info("Successfully deleted Fivetran connector", "connectorID", connector.Status.ConnectorID)
 	}
 
 	controllerutil.RemoveFinalizer(connector, fivetranFinalizer)


### PR DESCRIPTION
## Summary

- Adds annotation-based delete protection to `FivetranConnector` resources
- By default, deleting a CR now **orphans** the external Fivetran connector (preserves it in Fivetran)
- Only when `operator.dataverse.redhat.com/allow-deletion: "true"` annotation is set will both the CR and Fivetran connector be deleted

## Changes

- `internal/controller/fivetranconnector/constants.go` — Added `annotationAllowDeletion`, `ConnectorReasonDeletionOrphaned`, and `msgDeletionOrphaned` constants
- `internal/controller/fivetranconnector/controller.go` — Modified `handleDeletion` to check for the allow-deletion annotation before calling Fivetran API

## Usage

```bash
# Default: CR deleted, Fivetran connector preserved (orphaned)
kubectl delete fivetranconnector my-connector

# Full deletion: both CR and Fivetran connector deleted
kubectl annotate fivetranconnector my-connector operator.dataverse.redhat.com/allow-deletion=true
kubectl delete fivetranconnector my-connector
```

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet` passes
- [x] Linter passes (golangci-lint)

Jira: DATA-6517