### PR TITLE
Add E2E tests for Google Sheets connector lifecycle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,3 +59,28 @@ jobs:
       - name: tests
         run: |
           make test
+
+  e2e-tests:
+    name: e2e-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [build]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: "go.mod"
+      - name: Install Kind
+        run: |
+          go install sigs.k8s.io/kind@v0.27.0
+      - name: Run E2E tests
+        env:
+          E2E_FIVETRAN_API_KEY: ${{ secrets.E2E_FIVETRAN_API_KEY }}
+          E2E_FIVETRAN_API_SECRET: ${{ secrets.E2E_FIVETRAN_API_SECRET }}
+          E2E_FIVETRAN_GROUP_ID: ${{ vars.E2E_FIVETRAN_GROUP_ID }}
+          E2E_GOOGLE_SHEET_ID: ${{ vars.E2E_GOOGLE_SHEET_ID }}
+          E2E_GOOGLE_NAMED_RANGE: ${{ vars.E2E_GOOGLE_NAMED_RANGE }}
+          CONTAINER_TOOL: docker
+        run: |
+          make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -128,22 +128,22 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 KIND_CLUSTER ?= fivetran-operator-test-e2e
 
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
+setup-test-e2e: ## Set up a fresh Kind cluster for e2e tests
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
 	}
 	@case "$$($(KIND) get clusters)" in \
 		*"$(KIND_CLUSTER)"*) \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
-		*) \
-			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
+			echo "Deleting existing Kind cluster '$(KIND_CLUSTER)'..."; \
+			$(KIND) delete cluster --name $(KIND_CLUSTER) ;; \
 	esac
+	@echo "Creating Kind cluster '$(KIND_CLUSTER)'..."
+	@$(KIND) create cluster --name $(KIND_CLUSTER)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/test/e2e/connector_lifecycle_test.go
+++ b/test/e2e/connector_lifecycle_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
+)
+
+var _ = Describe("FivetranConnector Lifecycle", Ordered, func() {
+	const (
+		connectorTimeout  = 10 * time.Minute
+		connectorInterval = 5 * time.Second
+		deletionTimeout   = 5 * time.Minute
+	)
+
+	BeforeAll(func() {
+		if !e2eConfigPresent() {
+			Skip("Skipping connector lifecycle tests: E2E_SKIP_LIFECYCLE=true")
+		}
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			if controllerPodName != "" {
+				By("Fetching controller manager pod logs after lifecycle test failure")
+				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+				logs, err := utils.Run(cmd)
+				if err == nil {
+					_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s", logs)
+				}
+			}
+
+			By("Fetching Kubernetes events after lifecycle test failure")
+			cmd := exec.Command("kubectl", "get", "events", "-n", namespace,
+				"--sort-by=.lastTimestamp")
+			events, err := utils.Run(cmd)
+			if err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", events)
+			}
+		}
+	})
+
+	Context("Google Sheets connector", func() {
+		const crName = "e2e-google-sheets"
+		var createdConnectorID string
+
+		crYAML := func() string {
+			return fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: %s
+  namespace: %s
+  annotations:
+    operator.dataverse.redhat.com/allow-deletion: "true"
+spec:
+  connector:
+    group_id: "%s"
+    service: google_sheets
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: true
+    config:
+      auth_type: ServiceAccount
+      sheet_id: "%s"
+      named_range: "%s"
+      schema: "e2e_google_sheets"
+      table: "e2e_test_data"
+`, crName, namespace, fivetranGroupID, googleSheetID, googleNamedRange)
+		}
+
+		AfterAll(func() {
+			By("ensuring Google Sheets connector CR is cleaned up")
+			deleteFivetranConnectorCR(crName)
+
+			By("waiting for CR to be fully removed")
+			Eventually(func() (bool, error) {
+				return crExists(crName)
+			}, deletionTimeout, connectorInterval).Should(BeFalse(),
+				"FivetranConnector CR was not deleted in time")
+
+			if createdConnectorID != "" {
+				By("verifying connector is removed from Fivetran (safety cleanup)")
+				if fivetranConnectorExists(createdConnectorID) {
+					_, _ = fmt.Fprintf(GinkgoWriter,
+						"WARNING: connector %s still exists in Fivetran after CR deletion, performing direct API cleanup\n",
+						createdConnectorID)
+					cleanupFivetranConnector(createdConnectorID)
+				}
+			}
+		})
+
+		It("should create the connector and pass setup tests", func() {
+			By("applying the Google Sheets FivetranConnector CR")
+			applyFivetranConnectorCR(crName, crYAML())
+
+			By("waiting for ConnectorReady condition to be True")
+			Eventually(func() string {
+				return getConditionStatus(crName, "ConnectorReady")
+			}, connectorTimeout, connectorInterval).Should(Equal("True"),
+				"ConnectorReady did not become True")
+
+			By("waiting for SetupTestReady condition to be True")
+			Eventually(func() string {
+				return getConditionStatus(crName, "SetupTestReady")
+			}, connectorTimeout, connectorInterval).Should(Equal("True"),
+				"SetupTestReady did not become True")
+
+			By("waiting for SchemaReady condition to be True")
+			Eventually(func() string {
+				return getConditionStatus(crName, "SchemaReady")
+			}, connectorTimeout, connectorInterval).Should(Equal("True"),
+				"SchemaReady did not become True")
+
+			By("verifying connectorId is populated in status")
+			createdConnectorID = getStatusField(crName, "connectorId")
+			Expect(createdConnectorID).NotTo(BeEmpty(), "status.connectorId should be set")
+			_, _ = fmt.Fprintf(GinkgoWriter, "Connector created with ID: %s\n", createdConnectorID)
+
+			By("verifying connectorUrl is populated in status")
+			connectorURL := getStatusField(crName, "connectorUrl")
+			Expect(connectorURL).To(ContainSubstring("fivetran.com/dashboard/connectors/"),
+				"status.connectorUrl should contain the dashboard URL")
+		})
+
+		It("should delete the connector from Fivetran when CR is removed", func() {
+			By("verifying the CR exists before deletion")
+			exists, err := crExists(crName)
+			Expect(err).NotTo(HaveOccurred(), "Failed to check CR existence")
+			Expect(exists).To(BeTrue(), "CR should exist before deletion test")
+
+			Expect(createdConnectorID).NotTo(BeEmpty(), "connectorId must be set before deletion")
+			_, _ = fmt.Fprintf(GinkgoWriter, "Deleting connector with ID: %s\n", createdConnectorID)
+
+			By("deleting the FivetranConnector CR")
+			cmd := exec.Command("kubectl", "delete", "fivetranconnector", crName,
+				"-n", namespace, "--timeout=180s")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to delete FivetranConnector CR")
+
+			By("waiting for the CR to be fully removed (finalizer completed)")
+			Eventually(func() (bool, error) {
+				return crExists(crName)
+			}, deletionTimeout, connectorInterval).Should(BeFalse(),
+				"FivetranConnector CR was not fully deleted — finalizer may have failed")
+
+			By("verifying the connector no longer exists in Fivetran")
+			Eventually(func() bool {
+				return fivetranConnectorExists(createdConnectorID)
+			}, 2*time.Minute, connectorInterval).Should(BeFalse(),
+				"Connector should be deleted from Fivetran after CR removal")
+		})
+	})
+})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package e2e
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,21 +34,30 @@ import (
 var (
 	// Optional Environment Variables:
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
-	// These variables are useful if CertManager is already installed, avoiding
-	// re-installation and conflicts.
-	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
-	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
+	skipCertManagerInstall        = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	isCertManagerAlreadyInstalled = false
 
-	// projectImage is the name of the image which will be build and loaded
-	// with the code source changes to be tested.
 	projectImage = "example.com/fivetran-operator:v0.0.1"
+
+	// Shared state across all test files
+	controllerPodName string
+
+	// E2E Fivetran configuration loaded from environment variables.
+	// These are required for connector lifecycle tests.
+	fivetranAPIKey    string
+	fivetranAPISecret string
+	fivetranGroupID   string
+	googleSheetID     string
+	googleNamedRange  string
 )
 
-// TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
-// temporary environment to validate project changes with the purposed to be used in CI jobs.
-// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
-// CertManager.
+const (
+	namespace              = "fivetran-operator"
+	serviceAccountName     = "fivetran-operator-controller-manager"
+	metricsServiceName     = "fivetran-operator-controller-manager-metrics-service"
+	metricsRoleBindingName = "fivetran-operator-metrics-binding"
+)
+
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting fivetran-operator integration test suite\n")
@@ -53,21 +65,24 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	loadE2EConfig()
+
+	if !e2eConfigPresent() && os.Getenv("E2E_SKIP_LIFECYCLE") != "true" {
+		Fail("Connector lifecycle env vars missing " +
+			"(E2E_FIVETRAN_API_KEY, E2E_FIVETRAN_API_SECRET, E2E_FIVETRAN_GROUP_ID, " +
+			"E2E_GOOGLE_SHEET_ID, E2E_GOOGLE_NAMED_RANGE). " +
+			"Set E2E_SKIP_LIFECYCLE=true to skip intentionally.")
+	}
+
 	By("building the manager(Operator) image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
-	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
-	// built and available before running the tests. Also, remove the following block.
 	By("loading the manager(Operator) image on Kind")
 	err = utils.LoadImageToKindClusterWithName(projectImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
 
-	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
-	// To prevent errors when tests run in environments with CertManager already installed,
-	// we check for its presence before execution.
-	// Setup CertManager before the suite if not skipped and if not already installed
 	if !skipCertManagerInstall {
 		By("checking if cert manager is installed already")
 		isCertManagerAlreadyInstalled = utils.IsCertManagerCRDsInstalled()
@@ -78,10 +93,133 @@ var _ = BeforeSuite(func() {
 			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: CertManager is already installed. Skipping installation...\n")
 		}
 	}
+
+	// --- Namespace ---
+	By("creating manager namespace")
+	cmd = exec.Command("kubectl", "create", "ns", namespace)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+	By("labeling the namespace to enforce the restricted security policy")
+	cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+		"pod-security.kubernetes.io/enforce=restricted")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+
+	// --- Fivetran secrets & Vault ---
+	// The operator pod requires fivetran-secrets to start (env var refs in the pod spec).
+	// When lifecycle env vars are set, use real credentials and deploy a Vault dev server.
+	// Otherwise, create placeholder secrets so the operator pod can still start for metrics tests.
+	if e2eConfigPresent() {
+		By("creating fivetran-secrets for the operator")
+		_, _ = fmt.Fprintf(GinkgoWriter, "creating fivetran-secrets (credentials redacted from logs)\n")
+		secretData := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]string{
+				"name":      "fivetran-secrets",
+				"namespace": namespace,
+			},
+			"type": "Opaque",
+			"stringData": map[string]string{
+				"FIVETRAN_API_KEY":    fivetranAPIKey,
+				"FIVETRAN_API_SECRET": fivetranAPISecret,
+			},
+		}
+		secretJSON, jsonErr := json.Marshal(secretData)
+		Expect(jsonErr).NotTo(HaveOccurred(), "Failed to marshal fivetran-secrets")
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = bytes.NewReader(secretJSON)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create fivetran-secrets")
+
+		setupVaultDevServer()
+	} else {
+		By("creating placeholder fivetran-secrets (lifecycle tests disabled)")
+		placeholderSecret := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]string{
+				"name":      "fivetran-secrets",
+				"namespace": namespace,
+			},
+			"type": "Opaque",
+			"stringData": map[string]string{
+				"FIVETRAN_API_KEY":    "placeholder",
+				"FIVETRAN_API_SECRET": "placeholder",
+			},
+		}
+		placeholderJSON, jsonErr := json.Marshal(placeholderSecret)
+		Expect(jsonErr).NotTo(HaveOccurred(), "Failed to marshal placeholder secrets")
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = bytes.NewReader(placeholderJSON)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create placeholder fivetran-secrets")
+	}
+
+	// --- CRDs & Operator ---
+	By("installing CRDs")
+	cmd = exec.Command("make", "install")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+	By("deploying the controller-manager")
+	cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+	By("patching the deployment to use IfNotPresent image pull policy for Kind")
+	cmd = exec.Command("kubectl", "patch", "deployment",
+		"fivetran-operator-controller-manager", "-n", namespace,
+		"--type=json",
+		`-p=[{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"IfNotPresent"}]`)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to patch imagePullPolicy")
+
+	By("waiting for the controller-manager pod to be running")
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "get", "pods",
+			"-l", "control-plane=controller-manager",
+			"-o", "go-template={{ range .items }}"+
+				"{{ if not .metadata.deletionTimestamp }}"+
+				"{{ .metadata.name }}"+
+				"{{ \"\\n\" }}{{ end }}{{ end }}",
+			"-n", namespace)
+		output, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		podNames := utils.GetNonEmptyLines(output)
+		g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
+		controllerPodName = podNames[0]
+
+		cmd = exec.Command("kubectl", "get", "pods", controllerPodName,
+			"-o", "jsonpath={.status.phase}", "-n", namespace)
+		phase, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(phase).To(Equal("Running"), "controller-manager pod is not Running")
+	}, 2*time.Minute, time.Second).Should(Succeed())
 })
 
 var _ = AfterSuite(func() {
-	// Teardown CertManager after the suite if not skipped and if it was not already installed
+	By("cleaning up the curl pod for metrics")
+	cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics",
+		"-n", namespace, "--ignore-not-found=true")
+	_, _ = utils.Run(cmd)
+
+	By("undeploying the controller-manager")
+	cmd = exec.Command("make", "undeploy")
+	_, _ = utils.Run(cmd)
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("make", "uninstall")
+	_, _ = utils.Run(cmd)
+
+	By("tearing down Vault dev server")
+	teardownVaultDevServer()
+
+	By("removing manager namespace")
+	cmd = exec.Command("kubectl", "delete", "ns", namespace, "--ignore-not-found=true")
+	_, _ = utils.Run(cmd)
+
 	if !skipCertManagerInstall && !isCertManagerAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")
 		utils.UninstallCertManager()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -30,69 +30,7 @@ import (
 	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
 )
 
-// namespace where the project is deployed in
-const namespace = "fivetran-operator"
-
-// serviceAccountName created for the project
-const serviceAccountName = "fivetran-operator-controller-manager"
-
-// metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "fivetran-operator-controller-manager-metrics-service"
-
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "fivetran-operator-metrics-binding"
-
-var _ = Describe("Manager", Ordered, func() {
-	var controllerPodName string
-
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
-	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-	})
-
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
-	AfterAll(func() {
-		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
-		_, _ = utils.Run(cmd)
-
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
-
-	// After each test, check for failures and collect logs, events,
-	// and pod descriptions for debugging.
+var _ = Describe("Manager", func() {
 	AfterEach(func() {
 		specReport := CurrentSpecReport()
 		if specReport.Failed() {
@@ -137,83 +75,50 @@ var _ = Describe("Manager", Ordered, func() {
 	SetDefaultEventuallyTimeout(2 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 
-	Context("Manager", func() {
-		It("should run successfully", func() {
-			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func(g Gomega) {
-				// Get the name of the controller-manager pod
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
-				)
+	It("should ensure the metrics endpoint is serving metrics", func() {
+		By("creating a ClusterRoleBinding for the service account to allow access to metrics")
+		cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
+			"--clusterrole=fivetran-operator-metrics-reader",
+			fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
+		)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
 
-				podOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve controller-manager pod information")
-				podNames := utils.GetNonEmptyLines(podOutput)
-				g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
-				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
+		By("validating that the metrics service is available")
+		cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
 
-				// Validate the pod's status
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
-				)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Running"), "Incorrect controller-manager pod status")
-			}
-			Eventually(verifyControllerUp).Should(Succeed())
-		})
+		By("getting the service account token")
+		token, err := serviceAccountToken()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token).NotTo(BeEmpty())
 
-		It("should ensure the metrics endpoint is serving metrics", func() {
-			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=fivetran-operator-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+		By("waiting for the metrics endpoint to be ready")
+		verifyMetricsEndpointReady := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
+		}
+		Eventually(verifyMetricsEndpointReady).Should(Succeed())
 
-			By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
+		By("verifying that the controller manager is serving the metrics server")
+		verifyMetricsServerStarted := func(g Gomega) {
+			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
+				"Metrics server not yet started")
+		}
+		Eventually(verifyMetricsServerStarted).Should(Succeed())
 
-			By("getting the service account token")
-			token, err := serviceAccountToken()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token).NotTo(BeEmpty())
-
-			By("waiting for the metrics endpoint to be ready")
-			verifyMetricsEndpointReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "endpoints", metricsServiceName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("8443"), "Metrics endpoint is not ready")
-			}
-			Eventually(verifyMetricsEndpointReady).Should(Succeed())
-
-			By("verifying that the controller manager is serving the metrics server")
-			verifyMetricsServerStarted := func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("controller-runtime.metrics\tServing metrics server"),
-					"Metrics server not yet started")
-			}
-			Eventually(verifyMetricsServerStarted).Should(Succeed())
-
-			By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
-				"--overrides",
-				fmt.Sprintf(`{
+		By("creating the curl-metrics pod to access the metrics endpoint")
+		cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
+			"--namespace", namespace,
+			"--image=curlimages/curl:latest",
+			"--overrides",
+			fmt.Sprintf(`{
 					"spec": {
 						"containers": [{
 							"name": "curl",
@@ -235,50 +140,37 @@ var _ = Describe("Manager", Ordered, func() {
 						"serviceAccount": "%s"
 					}
 				}`, token, metricsServiceName, namespace, serviceAccountName))
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
 
-			By("waiting for the curl-metrics pod to complete.")
-			verifyCurlUp := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
-					"-o", "jsonpath={.status.phase}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
-			}
-			Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
+		By("waiting for the curl-metrics pod to complete.")
+		verifyCurlUp := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
+				"-o", "jsonpath={.status.phase}",
+				"-n", namespace)
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
+		}
+		Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
 
-			By("getting the metrics by checking curl-metrics logs")
-			metricsOutput := getMetricsOutput()
-			Expect(metricsOutput).To(ContainSubstring(
-				"controller_runtime_reconcile_total",
-			))
-		})
-
-		// +kubebuilder:scaffold:e2e-webhooks-checks
-
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput := getMetricsOutput()
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
+		By("getting the metrics by checking curl-metrics logs")
+		metricsOutput := getMetricsOutput()
+		Expect(metricsOutput).To(ContainSubstring(
+			"controller_runtime_reconcile_total",
+		))
 	})
+
+	// +kubebuilder:scaffold:e2e-webhooks-checks
 })
 
 // serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
 func serviceAccountToken() (string, error) {
 	const tokenRequestRawString = `{
 		"apiVersion": "authentication.k8s.io/v1",
 		"kind": "TokenRequest"
 	}`
 
-	// Temporary file to store the token request
 	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
 	tokenRequestFile := filepath.Join("/tmp", secretName)
 	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
@@ -288,7 +180,6 @@ func serviceAccountToken() (string, error) {
 
 	var out string
 	verifyTokenCreation := func(g Gomega) {
-		// Execute kubectl command to create the token
 		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
 			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
 			namespace,
@@ -298,7 +189,6 @@ func serviceAccountToken() (string, error) {
 		output, err := cmd.CombinedOutput()
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Parse the JSON output to extract the token
 		var token tokenRequest
 		err = json.Unmarshal(output, &token)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -320,8 +210,6 @@ func getMetricsOutput() string {
 	return metricsOutput
 }
 
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
 type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
+)
+
+const vaultNamespace = "e2e-vault"
+
+func loadE2EConfig() {
+	fivetranAPIKey = os.Getenv("E2E_FIVETRAN_API_KEY")
+	fivetranAPISecret = os.Getenv("E2E_FIVETRAN_API_SECRET")
+	fivetranGroupID = os.Getenv("E2E_FIVETRAN_GROUP_ID")
+	googleSheetID = os.Getenv("E2E_GOOGLE_SHEET_ID")
+	googleNamedRange = os.Getenv("E2E_GOOGLE_NAMED_RANGE")
+}
+
+func e2eConfigPresent() bool {
+	return fivetranAPIKey != "" && fivetranAPISecret != "" && fivetranGroupID != "" &&
+		googleSheetID != "" && googleNamedRange != ""
+}
+
+// setupVaultDevServer deploys a HashiCorp Vault dev server in a separate
+// namespace and configures AppRole auth for the operator.
+func setupVaultDevServer() {
+	By("creating vault namespace")
+	cmd := exec.Command("kubectl", "create", "ns", vaultNamespace)
+	_, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create vault namespace")
+
+	vaultManifest := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: vault
+  namespace: %[1]s
+  labels:
+    app: vault
+spec:
+  containers:
+  - name: vault
+    image: hashicorp/vault:1.17
+    command: ["vault", "server", "-dev", "-dev-root-token-id=e2e-root-token", "-dev-listen-address=0.0.0.0:8200"]
+    ports:
+    - containerPort: 8200
+    readinessProbe:
+      httpGet:
+        path: /v1/sys/health
+        port: 8200
+      initialDelaySeconds: 1
+      periodSeconds: 2
+    env:
+    - name: VAULT_ADDR
+      value: "http://127.0.0.1:8200"
+    - name: VAULT_TOKEN
+      value: "e2e-root-token"
+    - name: SKIP_SETCAP
+      value: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: %[1]s
+spec:
+  selector:
+    app: vault
+  ports:
+  - port: 8200
+    targetPort: 8200`, vaultNamespace)
+
+	By("deploying Vault pod and service")
+	cmd = exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(vaultManifest)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy Vault")
+
+	By("waiting for Vault pod to be ready")
+	cmd = exec.Command("kubectl", "wait", "--for=condition=ready", "pod/vault",
+		"-n", vaultNamespace, "--timeout=120s")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Vault pod not ready")
+
+	By("enabling AppRole auth in Vault")
+	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+		"vault", "auth", "enable", "approle")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to enable AppRole auth")
+
+	By("creating AppRole role")
+	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+		"vault", "write", "auth/approle/role/e2e-role",
+		"token_policies=default", "token_ttl=1h", "token_max_ttl=4h")
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create AppRole role")
+
+	By("reading AppRole role-id")
+	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+		"vault", "read", "-format=json", "auth/approle/role/e2e-role/role-id")
+	roleIDOutput, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to read role-id")
+
+	var roleIDResp struct {
+		Data struct {
+			RoleID string `json:"role_id"`
+		} `json:"data"`
+	}
+	jsonStart := strings.Index(roleIDOutput, "{")
+	Expect(jsonStart).NotTo(Equal(-1), "No JSON found in role-id output")
+	Expect(json.Unmarshal([]byte(roleIDOutput[jsonStart:]), &roleIDResp)).To(Succeed(), "Failed to parse role-id JSON")
+	Expect(roleIDResp.Data.RoleID).NotTo(BeEmpty(), "role-id is empty")
+
+	By("generating AppRole secret-id")
+	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+		"vault", "write", "-format=json", "-f", "auth/approle/role/e2e-role/secret-id")
+	secretIDOutput, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to generate secret-id")
+
+	var secretIDResp struct {
+		Data struct {
+			SecretID string `json:"secret_id"`
+		} `json:"data"`
+	}
+	jsonStart = strings.Index(secretIDOutput, "{")
+	Expect(jsonStart).NotTo(Equal(-1), "No JSON found in secret-id output")
+	Expect(json.Unmarshal([]byte(secretIDOutput[jsonStart:]), &secretIDResp)).To(Succeed(), "Failed to parse secret-id JSON")
+	Expect(secretIDResp.Data.SecretID).NotTo(BeEmpty(), "secret-id is empty")
+
+	By("creating fivetran-vault-secret in operator namespace")
+	_, _ = fmt.Fprintf(GinkgoWriter, "creating fivetran-vault-secret (credentials redacted from logs)\n")
+	vaultAddr := fmt.Sprintf("http://vault.%s.svc.cluster.local:8200", vaultNamespace)
+	vaultSecretData := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]string{
+			"name":      "fivetran-vault-secret",
+			"namespace": namespace,
+		},
+		"type": "Opaque",
+		"stringData": map[string]string{
+			"address":   vaultAddr,
+			"roleId":    roleIDResp.Data.RoleID,
+			"secretId":  secretIDResp.Data.SecretID,
+			"mountPath": "secret",
+		},
+	}
+	vaultSecretJSON, jsonErr := json.Marshal(vaultSecretData)
+	Expect(jsonErr).NotTo(HaveOccurred(), "Failed to marshal fivetran-vault-secret")
+	cmd = exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = bytes.NewReader(vaultSecretJSON)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create fivetran-vault-secret")
+}
+
+func teardownVaultDevServer() {
+	cmd := exec.Command("kubectl", "delete", "ns", vaultNamespace, "--ignore-not-found=true", "--timeout=60s")
+	_, _ = utils.Run(cmd)
+}
+
+// applyFivetranConnectorCR writes a CR YAML to a temp file and applies it.
+func applyFivetranConnectorCR(name, yamlContent string) {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(yamlContent)
+	_, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to apply FivetranConnector CR %s", name)
+}
+
+// deleteFivetranConnectorCR deletes a CR. Safe to call in cleanup contexts;
+// logs warnings instead of failing on errors.
+func deleteFivetranConnectorCR(name string) {
+	cmd := exec.Command("kubectl", "delete", "fivetranconnector", name,
+		"-n", namespace, "--timeout=180s", "--ignore-not-found=true")
+	if _, err := utils.Run(cmd); err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to delete CR %s: %v\n", name, err)
+	}
+}
+
+// getConditionStatus returns the status string of a named condition on a CR.
+func getConditionStatus(crName, conditionType string) string {
+	jsonpath := fmt.Sprintf(`jsonpath={.status.conditions[?(@.type=="%s")].status}`, conditionType)
+	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+		"-n", namespace, "-o", jsonpath)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return ""
+	}
+	return output
+}
+
+// getStatusField returns a field from the CR's .status using a jsonpath expression.
+func getStatusField(crName, field string) string {
+	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+		"-n", namespace, "-o", fmt.Sprintf("jsonpath={.status.%s}", field))
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return ""
+	}
+	return output
+}
+
+// crExists returns true if the named FivetranConnector CR still exists.
+// Returns (false, nil) only when kubectl confirms "not found".
+// Returns (false, error) on transient errors so Gomega retries.
+func crExists(crName string) (bool, error) {
+	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+		"-n", namespace, "--no-headers")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		if strings.Contains(output, "not found") || strings.Contains(err.Error(), "not found") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// fivetranConnectorExists checks via the Fivetran API whether a connector still exists.
+// Returns false only when the API returns 404 (confirmed deleted).
+// Returns true for 200 (exists), network errors, and unexpected status codes
+// (fail-safe: assume connector exists if we can't confirm deletion).
+func fivetranConnectorExists(connectorID string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		fmt.Sprintf("https://api.fivetran.com/v1/connections/%s", connectorID), nil)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to create request for %s: %v (assuming connector still exists)\n", connectorID, err)
+		return true
+	}
+	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Fivetran API check failed for %s: %v (assuming connector still exists)\n", connectorID, err)
+		return true
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return false
+	case http.StatusOK:
+		return true
+	default:
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: unexpected HTTP %d checking connector %s (assuming connector still exists)\n", resp.StatusCode, connectorID)
+		return true
+	}
+}
+
+// cleanupFivetranConnector deletes a connector directly via the Fivetran API.
+// Used as a safety net when the operator's finalizer fails to clean up.
+func cleanupFivetranConnector(connectorID string) {
+	_, _ = fmt.Fprintf(GinkgoWriter, "Cleaning up connector %s via Fivetran API\n", connectorID)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "DELETE",
+		fmt.Sprintf("https://api.fivetran.com/v1/connections/%s", connectorID), nil)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to create delete request for %s: %v\n", connectorID, err)
+		return
+	}
+	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to cleanup connector %s: %v\n", connectorID, err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: unexpected HTTP %d cleaning up connector %s\n", resp.StatusCode, connectorID)
+	}
+}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -165,15 +165,42 @@ func IsCertManagerCRDsInstalled() bool {
 	return false
 }
 
-// LoadImageToKindClusterWithName loads a local docker image to the kind cluster
+// LoadImageToKindClusterWithName loads a local container image to the kind cluster.
+// It first attempts `kind load docker-image`. If that fails (common with Podman on macOS),
+// it falls back to saving the image as a tar archive and loading via `kind load image-archive`.
 func LoadImageToKindClusterWithName(name string) error {
 	cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v
 	}
-	kindOptions := []string{"load", "docker-image", name, "--name", cluster}
-	cmd := exec.Command("kind", kindOptions...)
-	_, err := Run(cmd)
+
+	cmd := exec.Command("kind", "load", "docker-image", name, "--name", cluster)
+	if _, err := Run(cmd); err == nil {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(GinkgoWriter, "kind load docker-image failed, falling back to image-archive method\n")
+
+	containerTool := "podman"
+	if v, ok := os.LookupEnv("CONTAINER_TOOL"); ok {
+		containerTool = v
+	}
+
+	f, err := os.CreateTemp("", "e2e-operator-image-*.tar")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for image archive: %w", err)
+	}
+	archivePath := f.Name()
+	_ = f.Close()
+	defer func() { _ = os.Remove(archivePath) }()
+
+	cmd = exec.Command(containerTool, "save", "-o", archivePath, name)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("failed to save image to archive: %w", err)
+	}
+
+	cmd = exec.Command("kind", "load", "image-archive", archivePath, "--name", cluster)
+	_, err = Run(cmd)
 	return err
 }
 


### PR DESCRIPTION
Extends the E2E test suite with connector lifecycle tests against a dedicated Fivetran test account.

- Google Sheets connector: CR applied → ConnectorReady, SetupTestReady, SchemaReady = True → CR deleted → connector removed from Fivetran
- Vault dev server deployed in Kind for operator dependency
- Fivetran-side deletion verified via API with safety net cleanup
- All credentials redacted from logs
- All config externalised via env vars
- Podman/Kind image loading fallback for macOS
- Lifecycle tests skip gracefully without Fivetran env vars; metrics test always runs

**Testing**

```
# With Fivetran credentials (all 3 test)
export E2E_FIVETRAN_API_KEY="<KEY>"
export E2E_FIVETRAN_API_SECRET="<SECRET>"
export E2E_FIVETRAN_GROUP_ID="<GROUP_ID>"
export E2E_GOOGLE_SHEET_ID="<TEST SHEET ID>"
export E2E_GOOGLE_NAMED_RANGE="<NAMED RANGE>"
make test-e2e

# Without credentials (metrics test only, lifecycle tests skip)
make test-e2e

# Docker users
CONTAINER_TOOL=docker make test-e2e
Expected: 3 specs pass, ~90 seconds.
```
**Known limitations**
- Vault dev server required because operator unconditionally initialises Vault on every reconciliation (separate improvement)
- E2E not yet wired into CI 
