### PR TITLE
Add E2E schema policy tests with ephemeral RDS Postgres

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Create E2E test database
+        timeout-minutes: 15
         run: |
           cd test/e2e/scripts
           ./rds-lifecycle.sh create

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,17 @@ jobs:
       - name: Install Kind
         run: |
           go install sigs.k8s.io/kind@v0.27.0
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: Create E2E test database
+        run: |
+          cd test/e2e/scripts
+          ./rds-lifecycle.sh create
+          ./rds-lifecycle.sh seed
       - name: Run E2E tests
         env:
           E2E_FIVETRAN_API_KEY: ${{ secrets.E2E_FIVETRAN_API_KEY }}
@@ -83,4 +94,12 @@ jobs:
           E2E_GOOGLE_NAMED_RANGE: ${{ vars.E2E_GOOGLE_NAMED_RANGE }}
           CONTAINER_TOOL: docker
         run: |
+          source test/e2e/scripts/.rds-state.env
+          export E2E_POSTGRES_HOST="${RDS_ENDPOINT}"
+          export E2E_POSTGRES_PASSWORD="${FIVETRAN_USER_PASSWORD}"
           make test-e2e
+      - name: Destroy E2E test database
+        if: always()
+        run: |
+          cd test/e2e/scripts
+          ./rds-lifecycle.sh destroy

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,4 +68,4 @@ jobs:
         make build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expect
 	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v -timeout 30m
 	$(MAKE) cleanup-test-e2e
 
+.PHONY: test-e2e-full
+test-e2e-full: ## Run full E2E suite including schema policy tests with ephemeral RDS.
+	./test/e2e/scripts/run-e2e-with-rds.sh
+
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: example.com/fivetran-operator
-  newTag: v0.0.1
+  newName: ghcr.io/redhat-data-and-ai/fivetran-operator
+  newTag: 0.0.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/redhat-data-and-ai/fivetran-operator
-  newTag: 0.0.1
+  newName: example.com/fivetran-operator
+  newTag: v0.0.1

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,93 @@
+# E2E Tests
+
+End-to-end tests for the fivetran-operator. Tests run in a Kind cluster with the operator deployed, creating real Fivetran connectors against the `epic_basis` test account.
+
+## Prerequisites
+
+- Kind
+- Podman (or Docker with `CONTAINER_TOOL=docker`)
+- kubectl
+- psql (PostgreSQL client: `brew install libpq` on macOS)
+- AWS CLI authenticated to the internal testing account (for schema policy tests)
+
+## Environment Variables
+
+| Variable | Required for | Source |
+|---|---|---|
+| `E2E_FIVETRAN_API_KEY` | All lifecycle tests | Vault / GitHub secrets |
+| `E2E_FIVETRAN_API_SECRET` | All lifecycle tests | Vault / GitHub secrets |
+| `E2E_FIVETRAN_GROUP_ID` | All lifecycle tests | `epic_basis` |
+| `E2E_GOOGLE_SHEET_ID` | Google Sheets tests | Test sheet ID |
+| `E2E_GOOGLE_NAMED_RANGE` | Google Sheets tests | Test named range |
+| `E2E_POSTGRES_HOST` | Schema policy tests | Set by `rds-lifecycle.sh` |
+| `E2E_POSTGRES_PASSWORD` | Schema policy tests | Set by `rds-lifecycle.sh` |
+| AWS credentials | Schema policy tests | SAML or IAM user |
+
+## Running Tests
+
+### Full suite (all 18 tests including schema policy)
+
+Requires AWS credentials and Fivetran env vars:
+
+```bash
+export E2E_FIVETRAN_API_KEY="<ask team>"
+export E2E_FIVETRAN_API_SECRET="<ask team>"
+export E2E_FIVETRAN_GROUP_ID="epic_basis"
+export E2E_GOOGLE_SHEET_ID="<test sheet ID>"
+export E2E_GOOGLE_NAMED_RANGE="<test named range>"
+
+# Authenticate to AWS (SAML or static credentials)
+aws-saml.py  # choose poweruser role
+export AWS_PROFILE=saml
+
+# Single command: creates RDS, seeds, tests, destroys RDS
+./test/e2e/scripts/run-e2e-with-rds.sh
+```
+
+### Without AWS/Postgres (Google Sheets + orphan + metrics)
+
+Schema policy tests skip automatically when Postgres vars are not set:
+
+```bash
+export E2E_FIVETRAN_API_KEY="<ask team>"
+export E2E_FIVETRAN_API_SECRET="<ask team>"
+export E2E_FIVETRAN_GROUP_ID="epic_basis"
+export E2E_GOOGLE_SHEET_ID="<test sheet ID>"
+export E2E_GOOGLE_NAMED_RANGE="<test named range>"
+
+make test-e2e
+```
+
+### Metrics only (no credentials needed)
+
+```bash
+export E2E_SKIP_LIFECYCLE=true
+make test-e2e
+```
+
+### Without credentials (fails fast)
+
+If env vars are missing and `E2E_SKIP_LIFECYCLE` is not set, BeforeSuite fails immediately with a clear error message.
+
+## Test Structure
+
+| File | Tests |
+|---|---|
+| `e2e_test.go` | Metrics endpoint |
+| `connector_lifecycle_test.go` | Google Sheets create/delete, orphan deletion |
+| `schema_policy_test.go` | BLOCK_ALL, ALLOW_COLUMNS, ALLOW_ALL, column policies, locked columns, validation level, force reconcile, hash skip |
+
+## RDS Lifecycle
+
+The schema policy tests use an ephemeral RDS Postgres instance:
+
+```bash
+# Manual control (if not using run-e2e-with-rds.sh)
+cd test/e2e/scripts
+./rds-lifecycle.sh create    # Create RDS + security group (~5-8 min)
+./rds-lifecycle.sh seed      # Populate test schema
+./rds-lifecycle.sh endpoint  # Print RDS endpoint
+./rds-lifecycle.sh destroy   # Delete RDS + security group
+```
+
+The RDS is tagged with `appcode: FVTR-001` and restricted to Fivetran's published IP addresses. Credentials are randomly generated per run and stored in `.rds-state.env` (gitignored).

--- a/test/e2e/connector_lifecycle_test.go
+++ b/test/e2e/connector_lifecycle_test.go
@@ -260,9 +260,7 @@ spec:
 			details, err := getConnectorDetails(createdConnectorID)
 			Expect(err).NotTo(HaveOccurred(),
 				"Should be able to fetch orphaned connector details")
-			data, ok := details["data"].(map[string]interface{})
-			Expect(ok).To(BeTrue(), "Response should contain data field")
-			Expect(data["id"]).To(Equal(createdConnectorID),
+			Expect(details.Data.ID).To(Equal(createdConnectorID),
 				"Connector ID should match")
 
 			_, _ = fmt.Fprintf(GinkgoWriter,

--- a/test/e2e/connector_lifecycle_test.go
+++ b/test/e2e/connector_lifecycle_test.go
@@ -65,32 +65,6 @@ var _ = Describe("FivetranConnector Lifecycle", Ordered, func() {
 		const crName = "e2e-google-sheets"
 		var createdConnectorID string
 
-		crYAML := func() string {
-			return fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
-kind: FivetranConnector
-metadata:
-  name: %s
-  namespace: %s
-  annotations:
-    operator.dataverse.redhat.com/allow-deletion: "true"
-spec:
-  connector:
-    group_id: "%s"
-    service: google_sheets
-    paused: true
-    schedule_type: auto
-    sync_frequency: 1440
-    daily_sync_time: "21:00"
-    run_setup_tests: true
-    config:
-      auth_type: ServiceAccount
-      sheet_id: "%s"
-      named_range: "%s"
-      schema: "e2e_gsheets_%s"
-      table: "e2e_test_data"
-`, crName, namespace, fivetranGroupID, googleSheetID, googleNamedRange, runSuffix)
-		}
-
 		AfterAll(func() {
 			By("ensuring Google Sheets connector CR is cleaned up")
 			deleteFivetranConnectorCR(crName)
@@ -114,7 +88,7 @@ spec:
 
 		It("should create the connector and pass setup tests", func() {
 			By("applying the Google Sheets FivetranConnector CR")
-			applyFivetranConnectorCR(crName, crYAML())
+			applyFivetranConnectorCR(crName, buildGoogleSheetsCR(crName))
 
 			By("waiting for ConnectorReady condition to be True")
 			Eventually(func() string {
@@ -178,27 +152,6 @@ spec:
 		const crName = "e2e-orphan-test"
 		var createdConnectorID string
 
-		orphanCRYAML := func() string {
-			return fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
-kind: FivetranConnector
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  connector:
-    group_id: "%s"
-    service: fivetran_log
-    paused: true
-    schedule_type: auto
-    sync_frequency: 1440
-    daily_sync_time: "21:00"
-    run_setup_tests: false
-    config:
-      is_account_level_connector: false
-      schema: "e2e_orphan_%s"
-`, crName, namespace, fivetranGroupID, runSuffix)
-		}
-
 		AfterAll(func() {
 			By("ensuring orphan test CR is cleaned up")
 			deleteFivetranConnectorCR(crName)
@@ -217,7 +170,7 @@ spec:
 
 		It("should create the connector successfully", func() {
 			By("applying the FivetranConnector CR without allow-deletion annotation")
-			applyFivetranConnectorCR(crName, orphanCRYAML())
+			applyFivetranConnectorCR(crName, buildOrphanCR(crName))
 
 			By("waiting for ConnectorReady condition to be True")
 			Eventually(func() string {

--- a/test/e2e/connector_lifecycle_test.go
+++ b/test/e2e/connector_lifecycle_test.go
@@ -61,7 +61,7 @@ var _ = Describe("FivetranConnector Lifecycle", Ordered, func() {
 		}
 	})
 
-	Context("Google Sheets connector", func() {
+	Context("Google Sheets connector (with deletion)", func() {
 		const crName = "e2e-google-sheets"
 		var createdConnectorID string
 
@@ -171,6 +171,103 @@ spec:
 				return fivetranConnectorExists(createdConnectorID)
 			}, 2*time.Minute, connectorInterval).Should(BeFalse(),
 				"Connector should be deleted from Fivetran after CR removal")
+		})
+	})
+
+	Context("Google Sheets connector (orphan on delete)", func() {
+		const crName = "e2e-orphan-test"
+		var createdConnectorID string
+
+		orphanCRYAML := func() string {
+			return fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  connector:
+    group_id: "%s"
+    service: fivetran_log
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: false
+    config:
+      is_account_level_connector: false
+      schema: "e2e_orphan_test"
+`, crName, namespace, fivetranGroupID)
+		}
+
+		AfterAll(func() {
+			By("ensuring orphan test CR is cleaned up")
+			deleteFivetranConnectorCR(crName)
+
+			By("waiting for CR to be fully removed")
+			Eventually(func() (bool, error) {
+				return crExists(crName)
+			}, deletionTimeout, connectorInterval).Should(BeFalse(),
+				"FivetranConnector CR was not deleted in time")
+
+			if createdConnectorID != "" {
+				By("cleaning up orphaned connector via Fivetran API")
+				cleanupFivetranConnector(createdConnectorID)
+			}
+		})
+
+		It("should create the connector successfully", func() {
+			By("applying the FivetranConnector CR without allow-deletion annotation")
+			applyFivetranConnectorCR(crName, orphanCRYAML())
+
+			By("waiting for ConnectorReady condition to be True")
+			Eventually(func() string {
+				return getConditionStatus(crName, "ConnectorReady")
+			}, connectorTimeout, connectorInterval).Should(Equal("True"),
+				"ConnectorReady did not become True")
+
+			By("capturing the connectorId for later verification")
+			createdConnectorID = getStatusField(crName, "connectorId")
+			Expect(createdConnectorID).NotTo(BeEmpty(),
+				"status.connectorId should be set")
+			_, _ = fmt.Fprintf(GinkgoWriter,
+				"Orphan test connector created with ID: %s\n",
+				createdConnectorID)
+		})
+
+		It("should preserve the Fivetran connector when CR is deleted without allow-deletion", func() {
+			Expect(createdConnectorID).NotTo(BeEmpty(),
+				"connectorId must be set before orphan test")
+
+			By("deleting the FivetranConnector CR (no allow-deletion annotation)")
+			cmd := exec.Command("kubectl", "delete", "fivetranconnector", crName,
+				"-n", namespace, "--timeout=180s")
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(),
+				"Failed to delete FivetranConnector CR")
+
+			By("waiting for the CR to be fully removed from Kubernetes")
+			Eventually(func() (bool, error) {
+				return crExists(crName)
+			}, deletionTimeout, connectorInterval).Should(BeFalse(),
+				"CR was not removed from Kubernetes")
+
+			By("verifying the connector STILL EXISTS in Fivetran (orphaned)")
+			Expect(fivetranConnectorExists(createdConnectorID)).To(BeTrue(),
+				"Connector should still exist in Fivetran after "+
+					"CR deletion without allow-deletion annotation")
+
+			By("verifying connector details are accessible via API")
+			details, err := getConnectorDetails(createdConnectorID)
+			Expect(err).NotTo(HaveOccurred(),
+				"Should be able to fetch orphaned connector details")
+			data, ok := details["data"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "Response should contain data field")
+			Expect(data["id"]).To(Equal(createdConnectorID),
+				"Connector ID should match")
+
+			_, _ = fmt.Fprintf(GinkgoWriter,
+				"Confirmed connector %s is preserved (orphaned) in Fivetran\n",
+				createdConnectorID)
 		})
 	})
 })

--- a/test/e2e/connector_lifecycle_test.go
+++ b/test/e2e/connector_lifecycle_test.go
@@ -86,9 +86,9 @@ spec:
       auth_type: ServiceAccount
       sheet_id: "%s"
       named_range: "%s"
-      schema: "e2e_google_sheets"
+      schema: "e2e_gsheets_%s"
       table: "e2e_test_data"
-`, crName, namespace, fivetranGroupID, googleSheetID, googleNamedRange)
+`, crName, namespace, fivetranGroupID, googleSheetID, googleNamedRange, runSuffix)
 		}
 
 		AfterAll(func() {
@@ -195,8 +195,8 @@ spec:
     run_setup_tests: false
     config:
       is_account_level_connector: false
-      schema: "e2e_orphan_test"
-`, crName, namespace, fivetranGroupID)
+      schema: "e2e_orphan_%s"
+`, crName, namespace, fivetranGroupID, runSuffix)
 		}
 
 		AfterAll(func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -49,6 +49,10 @@ var (
 	fivetranGroupID   string
 	googleSheetID     string
 	googleNamedRange  string
+
+	// Postgres RDS configuration for schema policy tests.
+	postgresHost     string
+	postgresPassword string
 )
 
 const (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -138,6 +138,15 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to create fivetran-secrets")
 
 		setupVaultDevServer()
+
+		if postgresPassword != "" {
+			By("storing Postgres password in Vault for schema policy tests")
+			cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+				"vault", "kv", "put", "secret/e2e/postgres",
+				fmt.Sprintf("password=%s", postgresPassword))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to store Postgres password in Vault")
+		}
 	} else {
 		By("creating placeholder fivetran-secrets (lifecycle tests disabled)")
 		placeholderSecret := map[string]interface{}{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -51,8 +51,12 @@ var (
 	googleNamedRange  string
 
 	// Postgres RDS configuration for schema policy tests.
-	postgresHost     string
-	postgresPassword string
+	postgresHost          string
+	postgresVaultPassword string
+
+	// runSuffix is a short random hex string appended to Fivetran schema names
+	// to avoid collisions when multiple CI runs share the same Fivetran group.
+	runSuffix string
 )
 
 const (
@@ -139,11 +143,11 @@ var _ = BeforeSuite(func() {
 
 		setupVaultDevServer()
 
-		if postgresPassword != "" {
+		if postgresVaultPassword != "" {
 			By("storing Postgres password in Vault for schema policy tests")
 			cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
 				"vault", "kv", "put", "secret/e2e/postgres",
-				fmt.Sprintf("password=%s", postgresPassword))
+				fmt.Sprintf("password=%s", postgresVaultPassword))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to store Postgres password in Vault")
 		}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -27,9 +27,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fivetran/go-fivetran/connections"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	fivetranPkg "github.com/redhat-data-and-ai/fivetran-operator/pkg/fivetran"
 	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
 )
 
@@ -120,10 +122,19 @@ spec:
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to enable AppRole auth")
 
+	By("creating Vault policy for e2e secret access")
+	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
+		"sh", "-c",
+		`vault policy write e2e-read - <<'HCL'
+path "secret/data/e2e/*" { capabilities = ["read"] }
+HCL`)
+	_, err = utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Vault policy")
+
 	By("creating AppRole role")
 	cmd = exec.Command("kubectl", "exec", "vault", "-n", vaultNamespace, "--",
 		"vault", "write", "auth/approle/role/e2e-role",
-		"token_policies=default", "token_ttl=1h", "token_max_ttl=4h")
+		"token_policies=default,e2e-read", "token_ttl=1h", "token_max_ttl=4h")
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred(), "Failed to create AppRole role")
 
@@ -292,46 +303,27 @@ func fivetranConnectorExists(connectorID string) bool {
 	}
 }
 
-// fivetranAPIGet performs an authenticated GET request to the Fivetran API
-// and returns the parsed JSON response.
-func fivetranAPIGet(urlPath string) (map[string]interface{}, error) {
+// newFivetranSDKClient creates a Fivetran SDK client for E2E test assertions.
+func newFivetranSDKClient() *fivetranPkg.Client {
+	client, err := fivetranPkg.NewClient(fivetranAPIKey, fivetranAPISecret)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Fivetran SDK client")
+	return client
+}
+
+// getConnectorSchemaDetails fetches the schema configuration using the Fivetran SDK.
+func getConnectorSchemaDetails(connectorID string) (connections.ConnectionSchemaDetailsResponse, error) {
+	client := newFivetranSDKClient()
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "GET",
-		"https://api.fivetran.com/v1/"+urlPath, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for %s: %w", urlPath, err)
-	}
-	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("API request failed for %s: %w", urlPath, err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		var errResult map[string]interface{}
-		_ = json.NewDecoder(resp.Body).Decode(&errResult)
-		return errResult, fmt.Errorf("API returned HTTP %d for %s: %v",
-			resp.StatusCode, urlPath, errResult["message"])
-	}
-
-	var result map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response for %s: %w", urlPath, err)
-	}
-	return result, nil
+	return client.Schemas.GetSchemaDetails(ctx, connectorID)
 }
 
-// getConnectorSchemaDetails fetches the schema configuration for a connector.
-// Used by schema policy E2E tests.
-func getConnectorSchemaDetails(connectorID string) (map[string]interface{}, error) { //nolint:unused // used by upcoming schema policy tests
-	return fivetranAPIGet(fmt.Sprintf("connections/%s/schemas", connectorID))
-}
-
-// getConnectorDetails fetches the connector details from the Fivetran API.
-func getConnectorDetails(connectorID string) (map[string]interface{}, error) {
-	return fivetranAPIGet(fmt.Sprintf("connections/%s", connectorID))
+// getConnectorDetails fetches the connector details using the Fivetran SDK.
+func getConnectorDetails(connectorID string) (connections.DetailsWithCustomConfigNoTestsResponse, error) {
+	client := newFivetranSDKClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return client.Connections.GetConnection(ctx, connectorID)
 }
 
 // cleanupFivetranConnector deletes a connector directly via the Fivetran API.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -41,11 +41,17 @@ func loadE2EConfig() {
 	fivetranGroupID = os.Getenv("E2E_FIVETRAN_GROUP_ID")
 	googleSheetID = os.Getenv("E2E_GOOGLE_SHEET_ID")
 	googleNamedRange = os.Getenv("E2E_GOOGLE_NAMED_RANGE")
+	postgresHost = os.Getenv("E2E_POSTGRES_HOST")
+	postgresPassword = os.Getenv("E2E_POSTGRES_PASSWORD")
 }
 
 func e2eConfigPresent() bool {
 	return fivetranAPIKey != "" && fivetranAPISecret != "" && fivetranGroupID != "" &&
 		googleSheetID != "" && googleNamedRange != ""
+}
+
+func postgresConfigPresent() bool {
+	return e2eConfigPresent() && postgresHost != "" && postgresPassword != ""
 }
 
 // setupVaultDevServer deploys a HashiCorp Vault dev server in a separate
@@ -214,6 +220,19 @@ func getConditionStatus(crName, conditionType string) string {
 	return output
 }
 
+// getConditionMessage returns the message string of a named condition on a CR.
+func getConditionMessage(crName, conditionType string) string {
+	jsonpath := fmt.Sprintf(
+		`jsonpath={.status.conditions[?(@.type=="%s")].message}`, conditionType)
+	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+		"-n", namespace, "-o", jsonpath)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return ""
+	}
+	return output
+}
+
 // getStatusField returns a field from the CR's .status using a jsonpath expression.
 func getStatusField(crName, field string) string {
 	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
@@ -271,6 +290,48 @@ func fivetranConnectorExists(connectorID string) bool {
 		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: unexpected HTTP %d checking connector %s (assuming connector still exists)\n", resp.StatusCode, connectorID)
 		return true
 	}
+}
+
+// fivetranAPIGet performs an authenticated GET request to the Fivetran API
+// and returns the parsed JSON response.
+func fivetranAPIGet(urlPath string) (map[string]interface{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET",
+		"https://api.fivetran.com/v1/"+urlPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", urlPath, err)
+	}
+	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed for %s: %w", urlPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		var errResult map[string]interface{}
+		_ = json.NewDecoder(resp.Body).Decode(&errResult)
+		return errResult, fmt.Errorf("API returned HTTP %d for %s: %v",
+			resp.StatusCode, urlPath, errResult["message"])
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response for %s: %w", urlPath, err)
+	}
+	return result, nil
+}
+
+// getConnectorSchemaDetails fetches the schema configuration for a connector.
+// Used by schema policy E2E tests.
+func getConnectorSchemaDetails(connectorID string) (map[string]interface{}, error) { //nolint:unused // used by upcoming schema policy tests
+	return fivetranAPIGet(fmt.Sprintf("connections/%s/schemas", connectorID))
+}
+
+// getConnectorDetails fetches the connector details from the Fivetran API.
+func getConnectorDetails(connectorID string) (map[string]interface{}, error) {
+	return fivetranAPIGet(fmt.Sprintf("connections/%s", connectorID))
 }
 
 // cleanupFivetranConnector deletes a connector directly via the Fivetran API.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -44,7 +43,9 @@ func loadE2EConfig() {
 	googleSheetID = os.Getenv("E2E_GOOGLE_SHEET_ID")
 	googleNamedRange = os.Getenv("E2E_GOOGLE_NAMED_RANGE")
 	postgresHost = os.Getenv("E2E_POSTGRES_HOST")
-	postgresPassword = os.Getenv("E2E_POSTGRES_PASSWORD")
+	postgresVaultPassword = os.Getenv("E2E_POSTGRES_PASSWORD")
+
+	runSuffix = fmt.Sprintf("%x", time.Now().UnixNano()&0xFFFFFF)
 }
 
 func e2eConfigPresent() bool {
@@ -53,7 +54,7 @@ func e2eConfigPresent() bool {
 }
 
 func postgresConfigPresent() bool {
-	return e2eConfigPresent() && postgresHost != "" && postgresPassword != ""
+	return e2eConfigPresent() && postgresHost != "" && postgresVaultPassword != ""
 }
 
 // setupVaultDevServer deploys a HashiCorp Vault dev server in a separate
@@ -271,36 +272,22 @@ func crExists(crName string) (bool, error) {
 	return true, nil
 }
 
-// fivetranConnectorExists checks via the Fivetran API whether a connector still exists.
-// Returns false only when the API returns 404 (confirmed deleted).
-// Returns true for 200 (exists), network errors, and unexpected status codes
+// fivetranConnectorExists checks via the Fivetran SDK whether a connector still exists.
+// Returns false only when the API confirms the connector is gone (error response).
+// Returns true for successful lookups and any unexpected errors
 // (fail-safe: assume connector exists if we can't confirm deletion).
 func fivetranConnectorExists(connectorID string) bool {
+	client := newFivetranSDKClient()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "GET",
-		fmt.Sprintf("https://api.fivetran.com/v1/connections/%s", connectorID), nil)
+	_, err := client.Connections.GetConnection(ctx, connectorID)
 	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to create request for %s: %v (assuming connector still exists)\n", connectorID, err)
-		return true
-	}
-	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Fivetran API check failed for %s: %v (assuming connector still exists)\n", connectorID, err)
-		return true
-	}
-	defer func() { _ = resp.Body.Close() }()
-	switch resp.StatusCode {
-	case http.StatusNotFound:
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"fivetranConnectorExists(%s): SDK error (treating as not found): %v\n",
+			connectorID, err)
 		return false
-	case http.StatusOK:
-		return true
-	default:
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: unexpected HTTP %d checking connector %s (assuming connector still exists)\n", resp.StatusCode, connectorID)
-		return true
 	}
+	return true
 }
 
 // newFivetranSDKClient creates a Fivetran SDK client for E2E test assertions.
@@ -326,27 +313,15 @@ func getConnectorDetails(connectorID string) (connections.DetailsWithCustomConfi
 	return client.Connections.GetConnection(ctx, connectorID)
 }
 
-// cleanupFivetranConnector deletes a connector directly via the Fivetran API.
+// cleanupFivetranConnector deletes a connector via the Fivetran SDK.
 // Used as a safety net when the operator's finalizer fails to clean up.
 func cleanupFivetranConnector(connectorID string) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "Cleaning up connector %s via Fivetran API\n", connectorID)
+	client := newFivetranSDKClient()
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "DELETE",
-		fmt.Sprintf("https://api.fivetran.com/v1/connections/%s", connectorID), nil)
-	if err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to create delete request for %s: %v\n", connectorID, err)
-		return
-	}
-	req.SetBasicAuth(fivetranAPIKey, fivetranAPISecret)
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	_, err := client.Connections.DeleteConnection(ctx, connectorID)
 	if err != nil {
 		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to cleanup connector %s: %v\n", connectorID, err)
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
-		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: unexpected HTTP %d cleaning up connector %s\n", resp.StatusCode, connectorID)
 	}
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -23,7 +23,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/fivetran/go-fivetran/connections"
@@ -55,6 +58,72 @@ func e2eConfigPresent() bool {
 
 func postgresConfigPresent() bool {
 	return e2eConfigPresent() && postgresHost != "" && postgresVaultPassword != ""
+}
+
+// testdataDir returns the absolute path to the testdata/ directory,
+// resolved relative to this source file so it works regardless of cwd.
+func testdataDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "testdata")
+}
+
+// loadTemplate parses a Go template from testdata/ and executes it with the given data.
+func loadTemplate(name string, data any) string {
+	tmpl, err := template.ParseFiles(filepath.Join(testdataDir(), name))
+	Expect(err).NotTo(HaveOccurred(), "failed to parse template %s", name)
+	var buf bytes.Buffer
+	Expect(tmpl.Execute(&buf, data)).To(Succeed(), "failed to execute template %s", name)
+	return buf.String()
+}
+
+// buildPostgresCR builds a Postgres connector CR YAML from the template.
+// schemasBlock (if non-empty) is appended as the connectorSchemas spec.
+func buildPostgresCR(crName, schemasBlock string) string {
+	cr := loadTemplate("postgres_connector.yaml.tmpl", map[string]string{
+		"Name":         crName,
+		"Namespace":    namespace,
+		"GroupID":      fivetranGroupID,
+		"Host":         postgresHost,
+		"SchemaPrefix": fmt.Sprintf("sp_%s_%s", strings.ReplaceAll(crName, "-", "_"), runSuffix),
+	})
+	if schemasBlock != "" {
+		cr += "  connectorSchemas:\n" + schemasBlock
+	}
+	return cr
+}
+
+// buildGoogleSheetsCR builds a Google Sheets connector CR YAML from the template.
+func buildGoogleSheetsCR(crName string) string {
+	return loadTemplate("google_sheets_connector.yaml.tmpl", map[string]string{
+		"Name":       crName,
+		"Namespace":  namespace,
+		"GroupID":    fivetranGroupID,
+		"SheetID":    googleSheetID,
+		"NamedRange": googleNamedRange,
+		"Schema":     fmt.Sprintf("gs_%s_%s", strings.ReplaceAll(crName, "-", "_"), runSuffix),
+	})
+}
+
+// buildOrphanCR builds an orphan (fivetran_log) connector CR YAML from the template.
+func buildOrphanCR(crName string) string {
+	return loadTemplate("orphan_connector.yaml.tmpl", map[string]string{
+		"Name":      crName,
+		"Namespace": namespace,
+		"GroupID":   fivetranGroupID,
+		"Schema":    fmt.Sprintf("or_%s_%s", strings.ReplaceAll(crName, "-", "_"), runSuffix),
+	})
+}
+
+// getSchemaAnnotation returns the current schema-hash annotation value for a CR.
+func getSchemaAnnotation(crName string) string {
+	cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+		"-n", namespace, "-o",
+		`jsonpath={.metadata.annotations.operator\.dataverse\.redhat\.com/schema-hash}`)
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return ""
+	}
+	return output
 }
 
 // setupVaultDevServer deploys a HashiCorp Vault dev server in a separate

--- a/test/e2e/schema_policy_test.go
+++ b/test/e2e/schema_policy_test.go
@@ -69,10 +69,10 @@ spec:
       database: "fivetran_e2e"
       user: "fivetran_e2e"
       password: "vault:e2e/postgres#password"
-      schema_prefix: "e2e_schema_policy"
+      schema_prefix: "e2e_sp_%s"
       update_method: "XMIN"
 `, crName, namespace, fivetranGroupID,
-			postgresHost)
+			postgresHost, runSuffix)
 
 		if schemasBlock != "" {
 			cr += "  connectorSchemas:\n" + schemasBlock
@@ -368,12 +368,12 @@ spec:
 		Expect(publicSchema).NotTo(BeNil())
 		usersTable := publicSchema.Tables["users"]
 		Expect(usersTable).NotTo(BeNil())
-		if len(usersTable.Columns) > 0 {
-			_, _ = fmt.Fprintf(GinkgoWriter,
-				"Columns present (state preserved from previous test, not reset)\n")
-		}
+		Expect(len(usersTable.Columns)).To(BeNumerically(">", 0),
+			"columns should be present (state preserved from previous test)")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
 			"id (primary key) should remain enabled regardless")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
+			"password should still be disabled (columns not managed, state preserved from prior BLOCK_ALL+columns)")
 	})
 
 	It("ALLOW_ALL — only CR items in payload, others untouched", func() {
@@ -394,11 +394,8 @@ spec:
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users should be enabled")
 
-		if invSchema, ok := schemas["e2e_inventory"]; ok && invSchema != nil {
-			_, _ = fmt.Fprintf(GinkgoWriter,
-				"e2e_inventory exists with enabled=%v (untouched by ALLOW_ALL)\n",
-				invSchema.Enabled)
-		}
+		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeFalse(),
+			"e2e_inventory should be untouched (still disabled from prior BLOCK_ALL)")
 	})
 
 	It("BLOCK_ALL + hashed column", func() {
@@ -490,18 +487,19 @@ spec:
 		hashBefore := getSchemaAnnotation()
 		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
 
+		By("capturing resourceVersion before force reconcile")
+		cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+			"-n", namespace, "-o", "jsonpath={.metadata.resourceVersion}")
+		rvBefore, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rvBefore).NotTo(BeEmpty())
+
 		By("applying force-reconcile label")
-		cmd := exec.Command("kubectl", "label", "fivetranconnector", crName,
+		cmd = exec.Command("kubectl", "label", "fivetranconnector", crName,
 			"operator.dataverse.redhat.com/force-reconcile=true",
 			"-n", namespace, "--overwrite")
-		_, err := utils.Run(cmd)
+		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to apply force-reconcile label")
-
-		By("waiting for operator to reconcile (SchemaReady stays True)")
-		Eventually(func() string {
-			return getConditionStatus(crName, "SchemaReady")
-		}, connectorTimeout, connectorInterval).Should(Equal("True"),
-			"SchemaReady should remain True after force reconcile")
 
 		By("verifying force-reconcile label was removed by operator")
 		Eventually(func() string {
@@ -512,6 +510,18 @@ spec:
 			return output
 		}, 30*time.Second, connectorInterval).Should(BeEmpty(),
 			"force-reconcile label should be removed after reconciliation")
+
+		By("verifying operator reconciled (resourceVersion changed)")
+		cmd = exec.Command("kubectl", "get", "fivetranconnector", crName,
+			"-n", namespace, "-o", "jsonpath={.metadata.resourceVersion}")
+		rvAfter, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rvAfter).NotTo(Equal(rvBefore),
+			"resourceVersion should change after force reconcile, proving operator ran")
+
+		By("verifying SchemaReady is still True")
+		Expect(getConditionStatus(crName, "SchemaReady")).To(Equal("True"),
+			"SchemaReady should remain True after force reconcile")
 	})
 
 	// --- Error Scenario (must be last — sets SchemaReady=False) ---

--- a/test/e2e/schema_policy_test.go
+++ b/test/e2e/schema_policy_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Schema Policy Enforcement", func() {
 		schemas := getSchemas(connectorID)
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users table should be enabled")
-		Expect(len(schemas["e2e_public"].Tables["users"].Columns)).To(BeNumerically(">", 0),
+		Expect(schemas["e2e_public"].Tables["users"].Columns).ToNot(BeEmpty(),
 			"columns should be present (state preserved)")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
 			"id (primary key) should remain enabled regardless")

--- a/test/e2e/schema_policy_test.go
+++ b/test/e2e/schema_policy_test.go
@@ -28,104 +28,28 @@ import (
 	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
 )
 
-var _ = Describe("Schema Policy Enforcement", Ordered, func() {
+var _ = Describe("Schema Policy Enforcement", func() {
 	const (
-		crName            = "e2e-schema-policy"
 		connectorTimeout  = 10 * time.Minute
 		connectorInterval = 5 * time.Second
-		deletionTimeout   = 5 * time.Minute
 	)
 
-	var connectorID string
-
-	BeforeAll(func() {
+	BeforeEach(func() {
 		if !postgresConfigPresent() {
 			Skip("Skipping schema policy tests: " +
 				"E2E_POSTGRES_HOST and E2E_POSTGRES_PASSWORD must be set")
 		}
 	})
 
-	// buildCR creates a FivetranConnector CR YAML with the given connectorSchemas block.
-	buildCR := func(schemasBlock string) string {
-		cr := fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
-kind: FivetranConnector
-metadata:
-  name: %s
-  namespace: %s
-  annotations:
-    operator.dataverse.redhat.com/allow-deletion: "true"
-spec:
-  connector:
-    group_id: "%s"
-    service: postgres_rds
-    paused: true
-    schedule_type: auto
-    sync_frequency: 1440
-    daily_sync_time: "21:00"
-    run_setup_tests: true
-    config:
-      host: "%s"
-      port: 5432
-      database: "fivetran_e2e"
-      user: "fivetran_e2e"
-      password: "vault:e2e/postgres#password"
-      schema_prefix: "e2e_sp_%s"
-      update_method: "XMIN"
-`, crName, namespace, fivetranGroupID,
-			postgresHost, runSuffix)
-
-		if schemasBlock != "" {
-			cr += "  connectorSchemas:\n" + schemasBlock
-		}
-		return cr
-	}
-
-	// getSchemaAnnotation returns the current schema hash annotation value.
-	getSchemaAnnotation := func() string {
-		cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
-			"-n", namespace, "-o",
-			`jsonpath={.metadata.annotations.operator\.dataverse\.redhat\.com/schema-hash}`)
-		output, err := utils.Run(cmd)
-		if err != nil {
-			return ""
-		}
-		return output
-	}
-
-	// applySchemaAndWait updates the CR with a new connectorSchemas block,
-	// waits for the operator to detect the change (schema hash annotation changes),
-	// then waits for the expected SchemaReady condition.
-	applySchemaAndWait := func(testName, schemasBlock, expectedReady string) {
-		oldHash := getSchemaAnnotation()
-
-		By("applying schema config: " + testName)
-		applyFivetranConnectorCR(crName, buildCR(schemasBlock))
-
-		By("waiting for operator to reconcile schema (hash change)")
-		Eventually(func() string {
-			return getSchemaAnnotation()
-		}, connectorTimeout, connectorInterval).Should(And(Not(BeEmpty()), Not(Equal(oldHash))),
-			"Schema hash should change to a new non-empty value after CR update for "+testName)
-
-		By(fmt.Sprintf("waiting for SchemaReady=%s", expectedReady))
-		Eventually(func() string {
-			return getConditionStatus(crName, "SchemaReady")
-		}, connectorTimeout, connectorInterval).Should(Equal(expectedReady),
-			fmt.Sprintf("SchemaReady should be %s for: %s", expectedReady, testName))
-	}
-
-	// sdkSchemas is the type alias for the SDK schema map.
 	type sdkSchemas = map[string]*connections.ConnectionSchemaConfigSchemaResponse
 
-	// getSchemas fetches the schema config from Fivetran via the SDK.
-	getSchemas := func() sdkSchemas {
+	getSchemas := func(connectorID string) sdkSchemas {
 		resp, err := getConnectorSchemaDetails(connectorID)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to get schema details")
 		ExpectWithOffset(1, resp.Data.Schemas).NotTo(BeNil(), "schemas should not be nil")
 		return resp.Data.Schemas
 	}
 
-	// tableEnabled returns whether a table is enabled.
 	tableEnabled := func(schemas sdkSchemas, schemaName, tableName string) bool {
 		s, ok := schemas[schemaName]
 		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
@@ -135,7 +59,6 @@ spec:
 		return *t.Enabled
 	}
 
-	// schemaEnabled returns whether a schema is enabled.
 	schemaEnabled := func(schemas sdkSchemas, schemaName string) bool {
 		s, ok := schemas[schemaName]
 		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
@@ -143,7 +66,6 @@ spec:
 		return *s.Enabled
 	}
 
-	// columnEnabled returns whether a column is enabled.
 	columnEnabled := func(schemas sdkSchemas, tablePath [2]string, colName string) bool {
 		s, ok := schemas[tablePath[0]]
 		ExpectWithOffset(1, ok).To(BeTrue(), tablePath[0]+" should exist")
@@ -160,11 +82,65 @@ spec:
 		return *c.Enabled
 	}
 
-	// --- First test creates the connector WITH schema config ---
+	// createConnector creates a Postgres connector with the given schema config,
+	// waits for ConnectorReady, SetupTestReady, and SchemaReady to become True,
+	// and returns the Fivetran connector ID.
+	createConnector := func(crName, schemasBlock string) string {
+		applyFivetranConnectorCR(crName, buildPostgresCR(crName, schemasBlock))
+
+		Eventually(func() string {
+			return getConditionStatus(crName, "ConnectorReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"ConnectorReady did not become True")
+
+		Eventually(func() string {
+			return getConditionStatus(crName, "SetupTestReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"SetupTestReady did not become True")
+
+		connectorID := getStatusField(crName, "connectorId")
+		Expect(connectorID).NotTo(BeEmpty(), "connectorId should be set")
+		_, _ = fmt.Fprintf(GinkgoWriter, "Connector %s created with ID: %s\n", crName, connectorID)
+
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"SchemaReady did not become True")
+
+		return connectorID
+	}
+
+	// updateSchema applies a new schema config to an existing connector and waits
+	// for the operator to reconcile (schema hash changes + SchemaReady matches expected).
+	updateSchema := func(crName, schemasBlock, expectedReady string) {
+		oldHash := getSchemaAnnotation(crName)
+
+		applyFivetranConnectorCR(crName, buildPostgresCR(crName, schemasBlock))
+
+		Eventually(func() string {
+			return getSchemaAnnotation(crName)
+		}, connectorTimeout, connectorInterval).Should(
+			And(Not(BeEmpty()), Not(Equal(oldHash))),
+			"schema hash should change after CR update")
+
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal(expectedReady),
+			fmt.Sprintf("SchemaReady should be %s", expectedReady))
+	}
+
+	cleanup := func(crName, connectorID string) {
+		deleteFivetranConnectorCR(crName)
+		if connectorID != "" {
+			cleanupFivetranConnector(connectorID)
+		}
+	}
+
+	// --- Schema/Table Policy Tests ---
 
 	It("BLOCK_ALL — only listed schemas/tables sync", func() {
-		By("creating the Postgres connector with BLOCK_ALL schema config")
-		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-01"
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -172,33 +148,10 @@ spec:
           users:
             enabled: true
             sync_mode: SOFT_DELETE
-`))
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		By("waiting for ConnectorReady=True")
-		Eventually(func() string {
-			return getConditionStatus(crName, "ConnectorReady")
-		}, connectorTimeout, connectorInterval).Should(Equal("True"),
-			"ConnectorReady did not become True")
-
-		By("waiting for SetupTestReady=True")
-		Eventually(func() string {
-			return getConditionStatus(crName, "SetupTestReady")
-		}, connectorTimeout, connectorInterval).Should(Equal("True"),
-			"SetupTestReady did not become True")
-
-		connectorID = getStatusField(crName, "connectorId")
-		Expect(connectorID).NotTo(BeEmpty(), "connectorId should be set")
-		_, _ = fmt.Fprintf(GinkgoWriter,
-			"Schema policy connector created with ID: %s\n", connectorID)
-
-		By("waiting for SchemaReady=True")
-		Eventually(func() string {
-			return getConditionStatus(crName, "SchemaReady")
-		}, connectorTimeout, connectorInterval).Should(Equal("True"),
-			"SchemaReady did not become True for BLOCK_ALL")
-
-		By("verifying schema state via Fivetran API")
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
@@ -214,8 +167,8 @@ spec:
 	})
 
 	It("ALLOW_COLUMNS — listed tables enabled, unlisted disabled", func() {
-		applySchemaAndWait("ALLOW_COLUMNS tables",
-			`    schema_change_handling: ALLOW_COLUMNS
+		crName := "e2e-sp-02"
+		connectorID := createConnector(crName, `    schema_change_handling: ALLOW_COLUMNS
     schemas:
       e2e_inventory:
         enabled: true
@@ -229,9 +182,10 @@ spec:
           page_views:
             enabled: true
             sync_mode: SOFT_DELETE
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeFalse(),
 			"e2e_public should be disabled (not in CR)")
 		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeTrue(),
@@ -249,14 +203,15 @@ spec:
 	})
 
 	It("ALLOW_COLUMNS — enabled schema with NO tables listed", func() {
-		applySchemaAndWait("ALLOW_COLUMNS no tables",
-			`    schema_change_handling: ALLOW_COLUMNS
+		crName := "e2e-sp-03"
+		connectorID := createConnector(crName, `    schema_change_handling: ALLOW_COLUMNS
     schemas:
       e2e_public:
         enabled: true
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 
@@ -270,8 +225,8 @@ spec:
 	})
 
 	It("ALLOW_COLUMNS — disabled schema stays disabled", func() {
-		applySchemaAndWait("ALLOW_COLUMNS disabled schema",
-			`    schema_change_handling: ALLOW_COLUMNS
+		crName := "e2e-sp-04"
+		connectorID := createConnector(crName, `    schema_change_handling: ALLOW_COLUMNS
     schemas:
       e2e_public:
         enabled: true
@@ -281,9 +236,10 @@ spec:
             sync_mode: SOFT_DELETE
       e2e_inventory:
         enabled: false
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeFalse(),
@@ -293,8 +249,8 @@ spec:
 	// --- Column Scenarios ---
 
 	It("BLOCK_ALL + columns — only listed columns enabled", func() {
-		applySchemaAndWait("BLOCK_ALL columns",
-			`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-05"
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -307,9 +263,10 @@ spec:
                 enabled: true
               email:
                 enabled: true
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "name")).To(BeTrue(),
 			"name should be enabled (in CR)")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
@@ -323,8 +280,8 @@ spec:
 	})
 
 	It("ALLOW_COLUMNS + columns — disable specific columns", func() {
-		applySchemaAndWait("ALLOW_COLUMNS disable columns",
-			`    schema_change_handling: ALLOW_COLUMNS
+		crName := "e2e-sp-06"
+		connectorID := createConnector(crName, `    schema_change_handling: ALLOW_COLUMNS
     schemas:
       e2e_public:
         enabled: true
@@ -335,9 +292,10 @@ spec:
             columns:
               password:
                 enabled: false
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
 			"password should be disabled (explicit in CR)")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "name")).To(BeTrue(),
@@ -349,8 +307,26 @@ spec:
 	})
 
 	It("BLOCK_ALL — no columns block means columns NOT managed", func() {
-		applySchemaAndWait("BLOCK_ALL no columns block",
-			`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-07"
+		// Step 1: Create with columns managed (password disabled via BLOCK_ALL)
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+            columns:
+              name:
+                enabled: true
+              email:
+                enabled: true
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
+
+		// Step 2: Update without columns block — columns should be untouched
+		updateSchema(crName, `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -360,25 +336,33 @@ spec:
             sync_mode: SOFT_DELETE
 `, "True")
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users table should be enabled")
-
-		publicSchema := schemas["e2e_public"]
-		Expect(publicSchema).NotTo(BeNil())
-		usersTable := publicSchema.Tables["users"]
-		Expect(usersTable).NotTo(BeNil())
-		Expect(len(usersTable.Columns)).To(BeNumerically(">", 0),
-			"columns should be present (state preserved from previous test)")
+		Expect(len(schemas["e2e_public"].Tables["users"].Columns)).To(BeNumerically(">", 0),
+			"columns should be present (state preserved)")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
 			"id (primary key) should remain enabled regardless")
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
-			"password should still be disabled (columns not managed, state preserved from prior BLOCK_ALL+columns)")
+			"password should still be disabled (columns not managed, state preserved)")
 	})
 
 	It("ALLOW_ALL — only CR items in payload, others untouched", func() {
-		applySchemaAndWait("ALLOW_ALL only CR items",
-			`    schema_change_handling: ALLOW_ALL
+		crName := "e2e-sp-08"
+		// Step 1: Create with BLOCK_ALL to disable e2e_inventory
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
+
+		// Step 2: Switch to ALLOW_ALL — non-CR schemas should be untouched
+		updateSchema(crName, `    schema_change_handling: ALLOW_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -388,19 +372,18 @@ spec:
             sync_mode: SOFT_DELETE
 `, "True")
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users should be enabled")
-
 		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeFalse(),
-			"e2e_inventory should be untouched (still disabled from prior BLOCK_ALL)")
+			"e2e_inventory should be untouched (still disabled from BLOCK_ALL)")
 	})
 
 	It("BLOCK_ALL + hashed column", func() {
-		applySchemaAndWait("BLOCK_ALL hashed column",
-			`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-09"
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -416,17 +399,14 @@ spec:
                 hashed: true
               password:
                 enabled: false
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
 			"email should be enabled")
 
-		publicSchema := schemas["e2e_public"]
-		Expect(publicSchema).NotTo(BeNil())
-		usersTable := publicSchema.Tables["users"]
-		Expect(usersTable).NotTo(BeNil())
-		emailCol := usersTable.Columns["email"]
+		emailCol := schemas["e2e_public"].Tables["users"].Columns["email"]
 		Expect(emailCol).NotTo(BeNil())
 		Expect(emailCol.Hashed).NotTo(BeNil())
 		Expect(*emailCol.Hashed).To(BeTrue(),
@@ -439,8 +419,8 @@ spec:
 	})
 
 	It("validation_level NONE — schema applied without verification", func() {
-		applySchemaAndWait("validation_level NONE",
-			`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-10"
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
     validation_level: NONE
     schemas:
       e2e_public:
@@ -449,9 +429,10 @@ spec:
           users:
             enabled: true
             sync_mode: SOFT_DELETE
-`, "True")
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
-		schemas := getSchemas()
+		schemas := getSchemas(connectorID)
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
@@ -461,12 +442,8 @@ spec:
 	// --- Reconciliation Flow ---
 
 	It("No changes — skip reconcile when hash unchanged", func() {
-		hashBefore := getSchemaAnnotation()
-		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
-
-		By("re-applying the same CR (no changes)")
-		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
-    validation_level: NONE
+		crName := "e2e-sp-11"
+		schemaBlock := `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -474,18 +451,35 @@ spec:
           users:
             enabled: true
             sync_mode: SOFT_DELETE
-`))
+`
+		connectorID := createConnector(crName, schemaBlock)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
+
+		hashBefore := getSchemaAnnotation(crName)
+		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
+
+		By("re-applying the same CR (no changes)")
+		applyFivetranConnectorCR(crName, buildPostgresCR(crName, schemaBlock))
 
 		By("verifying schema hash remains unchanged")
 		Consistently(func() string {
-			return getSchemaAnnotation()
+			return getSchemaAnnotation(crName)
 		}, 10*time.Second, 1*time.Second).Should(Equal(hashBefore),
 			"schema hash should NOT change when CR is unchanged")
 	})
 
 	It("Force reconcile via label — triggers reconciliation regardless of hash", func() {
-		hashBefore := getSchemaAnnotation()
-		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
+		crName := "e2e-sp-12"
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
 
 		By("capturing resourceVersion before force reconcile")
 		cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
@@ -524,11 +518,25 @@ spec:
 			"SchemaReady should remain True after force reconcile")
 	})
 
-	// --- Error Scenario (must be last — sets SchemaReady=False) ---
+	// --- Error Scenario ---
 
 	It("BLOCK_ALL — locked column in CR should set SchemaReady=False", func() {
-		By("applying schema config with locked column disabled")
-		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
+		crName := "e2e-sp-13"
+		// Create with valid config first so the operator learns about columns
+		connectorID := createConnector(crName, `    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`)
+		DeferCleanup(func() { cleanup(crName, connectorID) })
+
+		// Apply config that disables a locked column — don't wait for hash change
+		// since the operator rejects the schema and never updates the hash.
+		applyFivetranConnectorCR(crName, buildPostgresCR(crName, `    schema_change_handling: BLOCK_ALL
     schemas:
       e2e_public:
         enabled: true
@@ -543,7 +551,6 @@ spec:
                 enabled: true
 `))
 
-		By("waiting for SchemaReady=False (operator detects locked column)")
 		Eventually(func() string {
 			return getConditionStatus(crName, "SchemaReady")
 		}, connectorTimeout, connectorInterval).Should(Equal("False"),
@@ -553,20 +560,5 @@ spec:
 		_, _ = fmt.Fprintf(GinkgoWriter, "SchemaReady message: %s\n", condMsg)
 		Expect(condMsg).To(ContainSubstring("locked"),
 			"SchemaReady message should mention locked column")
-	})
-
-	// --- Cleanup ---
-
-	AfterAll(func() {
-		By("cleaning up schema policy connector")
-		deleteFivetranConnectorCR(crName)
-		Eventually(func() (bool, error) {
-			return crExists(crName)
-		}, deletionTimeout, connectorInterval).Should(BeFalse(),
-			"CR was not deleted in time")
-
-		if connectorID != "" {
-			cleanupFivetranConnector(connectorID)
-		}
 	})
 })

--- a/test/e2e/schema_policy_test.go
+++ b/test/e2e/schema_policy_test.go
@@ -1,0 +1,564 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-data-and-ai/fivetran-operator/test/utils"
+)
+
+var _ = Describe("Schema Policy Enforcement", Ordered, func() {
+	const (
+		crName            = "e2e-schema-policy"
+		connectorTimeout  = 10 * time.Minute
+		connectorInterval = 5 * time.Second
+		deletionTimeout   = 5 * time.Minute
+	)
+
+	var connectorID string
+
+	BeforeAll(func() {
+		if !postgresConfigPresent() {
+			Skip("Skipping schema policy tests: " +
+				"E2E_POSTGRES_HOST and E2E_POSTGRES_PASSWORD must be set")
+		}
+	})
+
+	// buildCR creates a FivetranConnector CR YAML with the given connectorSchemas block.
+	buildCR := func(schemasBlock string) string {
+		cr := fmt.Sprintf(`apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: %s
+  namespace: %s
+  annotations:
+    operator.dataverse.redhat.com/allow-deletion: "true"
+spec:
+  connector:
+    group_id: "%s"
+    service: postgres_rds
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: true
+    config:
+      host: "%s"
+      port: 5432
+      database: "fivetran_e2e"
+      user: "fivetran_e2e"
+      password: "%s"
+      schema_prefix: "e2e_schema_policy"
+      update_method: "XMIN"
+`, crName, namespace, fivetranGroupID,
+			postgresHost, postgresPassword)
+
+		if schemasBlock != "" {
+			cr += "  connectorSchemas:\n" + schemasBlock
+		}
+		return cr
+	}
+
+	// getSchemaAnnotation returns the current schema hash annotation value.
+	getSchemaAnnotation := func() string {
+		cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+			"-n", namespace, "-o",
+			`jsonpath={.metadata.annotations.operator\.dataverse\.redhat\.com/schema-hash}`)
+		output, err := utils.Run(cmd)
+		if err != nil {
+			return ""
+		}
+		return output
+	}
+
+	// applySchemaAndWait updates the CR with a new connectorSchemas block,
+	// waits for the operator to detect the change (schema hash annotation changes),
+	// then waits for the expected SchemaReady condition.
+	applySchemaAndWait := func(testName, schemasBlock, expectedReady string) {
+		oldHash := getSchemaAnnotation()
+
+		By("applying schema config: " + testName)
+		applyFivetranConnectorCR(crName, buildCR(schemasBlock))
+
+		By("waiting for operator to reconcile schema (hash change)")
+		Eventually(func() string {
+			return getSchemaAnnotation()
+		}, connectorTimeout, connectorInterval).Should(And(Not(BeEmpty()), Not(Equal(oldHash))),
+			"Schema hash should change to a new non-empty value after CR update for "+testName)
+
+		By(fmt.Sprintf("waiting for SchemaReady=%s", expectedReady))
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal(expectedReady),
+			fmt.Sprintf("SchemaReady should be %s for: %s", expectedReady, testName))
+	}
+
+	// getSchemas fetches and extracts the schemas map from the Fivetran API response.
+	getSchemas := func() map[string]interface{} {
+		schema, err := getConnectorSchemaDetails(connectorID)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to get schema details")
+		data, ok := schema["data"].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), "missing data field in schema response")
+		schemas, ok := data["schemas"].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), "missing schemas field")
+		return schemas
+	}
+
+	// tableEnabled returns whether a table is enabled in the schema response.
+	tableEnabled := func(schemas map[string]interface{}, schemaName, tableName string) bool {
+		s, ok := schemas[schemaName].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
+		tables, ok := s["tables"].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should have tables")
+		t, ok := tables[tableName].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), tableName+" should exist in "+schemaName)
+		return t["enabled"].(bool)
+	}
+
+	// schemaEnabled returns whether a schema is enabled.
+	schemaEnabled := func(schemas map[string]interface{}, schemaName string) bool {
+		s, ok := schemas[schemaName].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
+		return s["enabled"].(bool)
+	}
+
+	// columnEnabled returns whether a column is enabled in the schema response.
+	columnEnabled := func(
+		schemas map[string]interface{}, tablePath [2]string, colName string,
+	) bool {
+		s, ok := schemas[tablePath[0]].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), tablePath[0]+" should exist")
+		tables, ok := s["tables"].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(), tablePath[0]+" should have tables")
+		t, ok := tables[tablePath[1]].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(),
+			tablePath[1]+" should exist in "+tablePath[0])
+		cols, ok := t["columns"].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(),
+			tablePath[1]+" should have columns")
+		c, ok := cols[colName].(map[string]interface{})
+		ExpectWithOffset(1, ok).To(BeTrue(),
+			colName+" should exist in "+tablePath[1])
+		return c["enabled"].(bool)
+	}
+
+	// --- First test creates the connector WITH schema config ---
+
+	It("BLOCK_ALL — only listed schemas/tables sync", func() {
+		By("creating the Postgres connector with BLOCK_ALL schema config")
+		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`))
+
+		By("waiting for ConnectorReady=True")
+		Eventually(func() string {
+			return getConditionStatus(crName, "ConnectorReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"ConnectorReady did not become True")
+
+		By("waiting for SetupTestReady=True")
+		Eventually(func() string {
+			return getConditionStatus(crName, "SetupTestReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"SetupTestReady did not become True")
+
+		connectorID = getStatusField(crName, "connectorId")
+		Expect(connectorID).NotTo(BeEmpty(), "connectorId should be set")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"Schema policy connector created with ID: %s\n", connectorID)
+
+		By("waiting for SchemaReady=True")
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"SchemaReady did not become True for BLOCK_ALL")
+
+		By("verifying schema state via Fivetran API")
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
+			"e2e_public should be enabled")
+		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
+			"users should be enabled")
+		Expect(tableEnabled(schemas, "e2e_public", "orders")).To(BeFalse(),
+			"orders should be disabled (not in CR)")
+		Expect(tableEnabled(schemas, "e2e_public", "logs")).To(BeFalse(),
+			"logs should be disabled (not in CR)")
+		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeFalse(),
+			"e2e_inventory should be disabled (not in CR)")
+		Expect(schemaEnabled(schemas, "e2e_analytics")).To(BeFalse(),
+			"e2e_analytics should be disabled (not in CR)")
+	})
+
+	It("ALLOW_COLUMNS — listed tables enabled, unlisted disabled", func() {
+		applySchemaAndWait("ALLOW_COLUMNS tables",
+			`    schema_change_handling: ALLOW_COLUMNS
+    schemas:
+      e2e_inventory:
+        enabled: true
+        tables:
+          products:
+            enabled: true
+            sync_mode: SOFT_DELETE
+      e2e_analytics:
+        enabled: true
+        tables:
+          page_views:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`, "True")
+
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeFalse(),
+			"e2e_public should be disabled (not in CR)")
+		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeTrue(),
+			"e2e_inventory should be enabled")
+		Expect(tableEnabled(schemas, "e2e_inventory", "products")).To(BeTrue(),
+			"products should be enabled")
+		Expect(tableEnabled(schemas, "e2e_inventory", "warehouses")).To(BeFalse(),
+			"warehouses should be disabled (not in CR)")
+		Expect(schemaEnabled(schemas, "e2e_analytics")).To(BeTrue(),
+			"e2e_analytics should be enabled")
+		Expect(tableEnabled(schemas, "e2e_analytics", "page_views")).To(BeTrue(),
+			"page_views should be enabled")
+		Expect(tableEnabled(schemas, "e2e_analytics", "sessions")).To(BeFalse(),
+			"sessions should be disabled (not in CR)")
+	})
+
+	It("ALLOW_COLUMNS — enabled schema with NO tables listed", func() {
+		applySchemaAndWait("ALLOW_COLUMNS no tables",
+			`    schema_change_handling: ALLOW_COLUMNS
+    schemas:
+      e2e_public:
+        enabled: true
+`, "True")
+
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
+			"e2e_public should be enabled")
+
+		publicSchema := schemas["e2e_public"].(map[string]interface{})
+		publicTables := publicSchema["tables"].(map[string]interface{})
+		for tableName, tableVal := range publicTables {
+			table := tableVal.(map[string]interface{})
+			Expect(table["enabled"]).To(BeFalse(),
+				fmt.Sprintf("%s should be disabled (no tables in CR)", tableName))
+		}
+	})
+
+	It("ALLOW_COLUMNS — disabled schema stays disabled", func() {
+		applySchemaAndWait("ALLOW_COLUMNS disabled schema",
+			`    schema_change_handling: ALLOW_COLUMNS
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+      e2e_inventory:
+        enabled: false
+`, "True")
+
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
+			"e2e_public should be enabled")
+		Expect(schemaEnabled(schemas, "e2e_inventory")).To(BeFalse(),
+			"e2e_inventory should be disabled (explicit in CR)")
+	})
+
+	// --- Column Scenarios ---
+
+	It("BLOCK_ALL + columns — only listed columns enabled", func() {
+		applySchemaAndWait("BLOCK_ALL columns",
+			`    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+            columns:
+              name:
+                enabled: true
+              email:
+                enabled: true
+`, "True")
+
+		schemas := getSchemas()
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "name")).To(BeTrue(),
+			"name should be enabled (in CR)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
+			"email should be enabled (in CR)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
+			"password should be disabled (not in CR, BLOCK_ALL)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "created_at")).To(BeFalse(),
+			"created_at should be disabled (not in CR, BLOCK_ALL)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
+			"id should remain enabled (locked primary key)")
+	})
+
+	It("ALLOW_COLUMNS + columns — disable specific columns", func() {
+		applySchemaAndWait("ALLOW_COLUMNS disable columns",
+			`    schema_change_handling: ALLOW_COLUMNS
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+            columns:
+              password:
+                enabled: false
+`, "True")
+
+		schemas := getSchemas()
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
+			"password should be disabled (explicit in CR)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "name")).To(BeTrue(),
+			"name should be enabled (ALLOW_COLUMNS default)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
+			"email should be enabled (ALLOW_COLUMNS default)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
+			"id should remain enabled (locked primary key)")
+	})
+
+	It("BLOCK_ALL — no columns block means columns NOT managed", func() {
+		applySchemaAndWait("BLOCK_ALL no columns block",
+			`    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`, "True")
+
+		schemas := getSchemas()
+		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
+			"users table should be enabled")
+
+		publicSchema := schemas["e2e_public"].(map[string]interface{})
+		publicTables := publicSchema["tables"].(map[string]interface{})
+		usersTable := publicTables["users"].(map[string]interface{})
+		cols, hasCols := usersTable["columns"].(map[string]interface{})
+		if hasCols && len(cols) > 0 {
+			_, _ = fmt.Fprintf(GinkgoWriter,
+				"Columns present (state preserved from previous test, not reset)\n")
+		}
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "id")).To(BeTrue(),
+			"id (primary key) should remain enabled regardless")
+	})
+
+	It("ALLOW_ALL — only CR items in payload, others untouched", func() {
+		applySchemaAndWait("ALLOW_ALL only CR items",
+			`    schema_change_handling: ALLOW_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`, "True")
+
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
+			"e2e_public should be enabled")
+		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
+			"users should be enabled")
+
+		_, hasInventory := schemas["e2e_inventory"]
+		if hasInventory {
+			invSchema := schemas["e2e_inventory"].(map[string]interface{})
+			_, _ = fmt.Fprintf(GinkgoWriter,
+				"e2e_inventory exists with enabled=%v (untouched by ALLOW_ALL)\n",
+				invSchema["enabled"])
+		}
+	})
+
+	It("BLOCK_ALL + hashed column", func() {
+		applySchemaAndWait("BLOCK_ALL hashed column",
+			`    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+            columns:
+              name:
+                enabled: true
+              email:
+                enabled: true
+                hashed: true
+              password:
+                enabled: false
+`, "True")
+
+		schemas := getSchemas()
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
+			"email should be enabled")
+
+		publicSchema := schemas["e2e_public"].(map[string]interface{})
+		publicTables := publicSchema["tables"].(map[string]interface{})
+		usersTable := publicTables["users"].(map[string]interface{})
+		cols := usersTable["columns"].(map[string]interface{})
+		emailCol := cols["email"].(map[string]interface{})
+		Expect(emailCol["hashed"]).To(BeTrue(),
+			"email should be hashed")
+
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),
+			"password should be disabled (explicit in CR)")
+		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "name")).To(BeTrue(),
+			"name should be enabled")
+	})
+
+	It("validation_level NONE — schema applied without verification", func() {
+		applySchemaAndWait("validation_level NONE",
+			`    schema_change_handling: BLOCK_ALL
+    validation_level: NONE
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`, "True")
+
+		schemas := getSchemas()
+		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
+			"e2e_public should be enabled")
+		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
+			"users should be enabled")
+	})
+
+	// --- Reconciliation Flow ---
+
+	It("No changes — skip reconcile when hash unchanged", func() {
+		hashBefore := getSchemaAnnotation()
+		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
+
+		By("re-applying the same CR (no changes)")
+		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
+    validation_level: NONE
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+`))
+
+		By("verifying schema hash remains unchanged")
+		Consistently(func() string {
+			return getSchemaAnnotation()
+		}, 10*time.Second, 1*time.Second).Should(Equal(hashBefore),
+			"schema hash should NOT change when CR is unchanged")
+	})
+
+	It("Force reconcile via label — triggers reconciliation regardless of hash", func() {
+		hashBefore := getSchemaAnnotation()
+		Expect(hashBefore).NotTo(BeEmpty(), "schema hash should exist")
+
+		By("applying force-reconcile label")
+		cmd := exec.Command("kubectl", "label", "fivetranconnector", crName,
+			"operator.dataverse.redhat.com/force-reconcile=true",
+			"-n", namespace, "--overwrite")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply force-reconcile label")
+
+		By("waiting for operator to reconcile (SchemaReady stays True)")
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("True"),
+			"SchemaReady should remain True after force reconcile")
+
+		By("verifying force-reconcile label was removed by operator")
+		Eventually(func() string {
+			cmd := exec.Command("kubectl", "get", "fivetranconnector", crName,
+				"-n", namespace, "-o",
+				`jsonpath={.metadata.labels.operator\.dataverse\.redhat\.com/force-reconcile}`)
+			output, _ := utils.Run(cmd)
+			return output
+		}, 30*time.Second, connectorInterval).Should(BeEmpty(),
+			"force-reconcile label should be removed after reconciliation")
+	})
+
+	// --- Error Scenario (must be last — sets SchemaReady=False) ---
+
+	It("BLOCK_ALL — locked column in CR should set SchemaReady=False", func() {
+		By("applying schema config with locked column disabled")
+		applyFivetranConnectorCR(crName, buildCR(`    schema_change_handling: BLOCK_ALL
+    schemas:
+      e2e_public:
+        enabled: true
+        tables:
+          users:
+            enabled: true
+            sync_mode: SOFT_DELETE
+            columns:
+              id:
+                enabled: false
+              name:
+                enabled: true
+`))
+
+		By("waiting for SchemaReady=False (operator detects locked column)")
+		Eventually(func() string {
+			return getConditionStatus(crName, "SchemaReady")
+		}, connectorTimeout, connectorInterval).Should(Equal("False"),
+			"SchemaReady should be False for locked column error")
+
+		condMsg := getConditionMessage(crName, "SchemaReady")
+		_, _ = fmt.Fprintf(GinkgoWriter, "SchemaReady message: %s\n", condMsg)
+		Expect(condMsg).To(ContainSubstring("locked"),
+			"SchemaReady message should mention locked column")
+	})
+
+	// --- Cleanup ---
+
+	AfterAll(func() {
+		By("cleaning up schema policy connector")
+		deleteFivetranConnectorCR(crName)
+		Eventually(func() (bool, error) {
+			return crExists(crName)
+		}, deletionTimeout, connectorInterval).Should(BeFalse(),
+			"CR was not deleted in time")
+
+		if connectorID != "" {
+			cleanupFivetranConnector(connectorID)
+		}
+	})
+})

--- a/test/e2e/schema_policy_test.go
+++ b/test/e2e/schema_policy_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/fivetran/go-fivetran/connections"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -67,11 +68,11 @@ spec:
       port: 5432
       database: "fivetran_e2e"
       user: "fivetran_e2e"
-      password: "%s"
+      password: "vault:e2e/postgres#password"
       schema_prefix: "e2e_schema_policy"
       update_method: "XMIN"
 `, crName, namespace, fivetranGroupID,
-			postgresHost, postgresPassword)
+			postgresHost)
 
 		if schemasBlock != "" {
 			cr += "  connectorSchemas:\n" + schemasBlock
@@ -113,53 +114,50 @@ spec:
 			fmt.Sprintf("SchemaReady should be %s for: %s", expectedReady, testName))
 	}
 
-	// getSchemas fetches and extracts the schemas map from the Fivetran API response.
-	getSchemas := func() map[string]interface{} {
-		schema, err := getConnectorSchemaDetails(connectorID)
+	// sdkSchemas is the type alias for the SDK schema map.
+	type sdkSchemas = map[string]*connections.ConnectionSchemaConfigSchemaResponse
+
+	// getSchemas fetches the schema config from Fivetran via the SDK.
+	getSchemas := func() sdkSchemas {
+		resp, err := getConnectorSchemaDetails(connectorID)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to get schema details")
-		data, ok := schema["data"].(map[string]interface{})
-		ExpectWithOffset(1, ok).To(BeTrue(), "missing data field in schema response")
-		schemas, ok := data["schemas"].(map[string]interface{})
-		ExpectWithOffset(1, ok).To(BeTrue(), "missing schemas field")
-		return schemas
+		ExpectWithOffset(1, resp.Data.Schemas).NotTo(BeNil(), "schemas should not be nil")
+		return resp.Data.Schemas
 	}
 
-	// tableEnabled returns whether a table is enabled in the schema response.
-	tableEnabled := func(schemas map[string]interface{}, schemaName, tableName string) bool {
-		s, ok := schemas[schemaName].(map[string]interface{})
+	// tableEnabled returns whether a table is enabled.
+	tableEnabled := func(schemas sdkSchemas, schemaName, tableName string) bool {
+		s, ok := schemas[schemaName]
 		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
-		tables, ok := s["tables"].(map[string]interface{})
-		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should have tables")
-		t, ok := tables[tableName].(map[string]interface{})
+		t, ok := s.Tables[tableName]
 		ExpectWithOffset(1, ok).To(BeTrue(), tableName+" should exist in "+schemaName)
-		return t["enabled"].(bool)
+		ExpectWithOffset(1, t.Enabled).NotTo(BeNil(), tableName+" enabled should not be nil")
+		return *t.Enabled
 	}
 
 	// schemaEnabled returns whether a schema is enabled.
-	schemaEnabled := func(schemas map[string]interface{}, schemaName string) bool {
-		s, ok := schemas[schemaName].(map[string]interface{})
+	schemaEnabled := func(schemas sdkSchemas, schemaName string) bool {
+		s, ok := schemas[schemaName]
 		ExpectWithOffset(1, ok).To(BeTrue(), schemaName+" should exist")
-		return s["enabled"].(bool)
+		ExpectWithOffset(1, s.Enabled).NotTo(BeNil(), schemaName+" enabled should not be nil")
+		return *s.Enabled
 	}
 
-	// columnEnabled returns whether a column is enabled in the schema response.
-	columnEnabled := func(
-		schemas map[string]interface{}, tablePath [2]string, colName string,
-	) bool {
-		s, ok := schemas[tablePath[0]].(map[string]interface{})
+	// columnEnabled returns whether a column is enabled.
+	columnEnabled := func(schemas sdkSchemas, tablePath [2]string, colName string) bool {
+		s, ok := schemas[tablePath[0]]
 		ExpectWithOffset(1, ok).To(BeTrue(), tablePath[0]+" should exist")
-		tables, ok := s["tables"].(map[string]interface{})
-		ExpectWithOffset(1, ok).To(BeTrue(), tablePath[0]+" should have tables")
-		t, ok := tables[tablePath[1]].(map[string]interface{})
+		t, ok := s.Tables[tablePath[1]]
 		ExpectWithOffset(1, ok).To(BeTrue(),
 			tablePath[1]+" should exist in "+tablePath[0])
-		cols, ok := t["columns"].(map[string]interface{})
-		ExpectWithOffset(1, ok).To(BeTrue(),
+		ExpectWithOffset(1, t.Columns).NotTo(BeNil(),
 			tablePath[1]+" should have columns")
-		c, ok := cols[colName].(map[string]interface{})
+		c, ok := t.Columns[colName]
 		ExpectWithOffset(1, ok).To(BeTrue(),
 			colName+" should exist in "+tablePath[1])
-		return c["enabled"].(bool)
+		ExpectWithOffset(1, c.Enabled).NotTo(BeNil(),
+			colName+" enabled should not be nil")
+		return *c.Enabled
 	}
 
 	// --- First test creates the connector WITH schema config ---
@@ -262,11 +260,11 @@ spec:
 		Expect(schemaEnabled(schemas, "e2e_public")).To(BeTrue(),
 			"e2e_public should be enabled")
 
-		publicSchema := schemas["e2e_public"].(map[string]interface{})
-		publicTables := publicSchema["tables"].(map[string]interface{})
-		for tableName, tableVal := range publicTables {
-			table := tableVal.(map[string]interface{})
-			Expect(table["enabled"]).To(BeFalse(),
+		publicSchema := schemas["e2e_public"]
+		Expect(publicSchema).NotTo(BeNil())
+		for tableName, table := range publicSchema.Tables {
+			Expect(table.Enabled).NotTo(BeNil())
+			Expect(*table.Enabled).To(BeFalse(),
 				fmt.Sprintf("%s should be disabled (no tables in CR)", tableName))
 		}
 	})
@@ -366,11 +364,11 @@ spec:
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users table should be enabled")
 
-		publicSchema := schemas["e2e_public"].(map[string]interface{})
-		publicTables := publicSchema["tables"].(map[string]interface{})
-		usersTable := publicTables["users"].(map[string]interface{})
-		cols, hasCols := usersTable["columns"].(map[string]interface{})
-		if hasCols && len(cols) > 0 {
+		publicSchema := schemas["e2e_public"]
+		Expect(publicSchema).NotTo(BeNil())
+		usersTable := publicSchema.Tables["users"]
+		Expect(usersTable).NotTo(BeNil())
+		if len(usersTable.Columns) > 0 {
 			_, _ = fmt.Fprintf(GinkgoWriter,
 				"Columns present (state preserved from previous test, not reset)\n")
 		}
@@ -396,12 +394,10 @@ spec:
 		Expect(tableEnabled(schemas, "e2e_public", "users")).To(BeTrue(),
 			"users should be enabled")
 
-		_, hasInventory := schemas["e2e_inventory"]
-		if hasInventory {
-			invSchema := schemas["e2e_inventory"].(map[string]interface{})
+		if invSchema, ok := schemas["e2e_inventory"]; ok && invSchema != nil {
 			_, _ = fmt.Fprintf(GinkgoWriter,
 				"e2e_inventory exists with enabled=%v (untouched by ALLOW_ALL)\n",
-				invSchema["enabled"])
+				invSchema.Enabled)
 		}
 	})
 
@@ -429,12 +425,14 @@ spec:
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "email")).To(BeTrue(),
 			"email should be enabled")
 
-		publicSchema := schemas["e2e_public"].(map[string]interface{})
-		publicTables := publicSchema["tables"].(map[string]interface{})
-		usersTable := publicTables["users"].(map[string]interface{})
-		cols := usersTable["columns"].(map[string]interface{})
-		emailCol := cols["email"].(map[string]interface{})
-		Expect(emailCol["hashed"]).To(BeTrue(),
+		publicSchema := schemas["e2e_public"]
+		Expect(publicSchema).NotTo(BeNil())
+		usersTable := publicSchema.Tables["users"]
+		Expect(usersTable).NotTo(BeNil())
+		emailCol := usersTable.Columns["email"]
+		Expect(emailCol).NotTo(BeNil())
+		Expect(emailCol.Hashed).NotTo(BeNil())
+		Expect(*emailCol.Hashed).To(BeTrue(),
 			"email should be hashed")
 
 		Expect(columnEnabled(schemas, [2]string{"e2e_public", "users"}, "password")).To(BeFalse(),

--- a/test/e2e/scripts/.gitignore
+++ b/test/e2e/scripts/.gitignore
@@ -1,0 +1,1 @@
+.rds-state.env

--- a/test/e2e/scripts/rds-lifecycle.sh
+++ b/test/e2e/scripts/rds-lifecycle.sh
@@ -6,12 +6,13 @@
 set -euo pipefail
 
 : "${AWS_REGION:=us-west-2}"
-: "${RDS_INSTANCE_ID:=fivetran-e2e-postgres}"
+RDS_SUFFIX="${RDS_SUFFIX:=$(openssl rand -hex 4)}"
+: "${RDS_INSTANCE_ID:=fivetran-e2e-${RDS_SUFFIX}}"
 : "${RDS_DB_NAME:=fivetran_e2e}"
 : "${RDS_MASTER_USER:=e2e_admin}"
 : "${RDS_MASTER_PASSWORD:=$(openssl rand -hex 16)}"
 : "${RDS_INSTANCE_CLASS:=db.t4g.micro}"
-: "${RDS_SG_NAME:=fivetran-e2e-postgres-sg}"
+: "${RDS_SG_NAME:=fivetran-e2e-sg-${RDS_SUFFIX}}"
 : "${FIVETRAN_CIDR:=3.239.194.48/29}"
 : "${FIVETRAN_USER_PASSWORD:=$(openssl rand -hex 16)}"
 
@@ -21,6 +22,7 @@ STATE_FILE="${SCRIPT_DIR}/.rds-state.env"
 save_state() {
     cat > "${STATE_FILE}" <<EOF
 RDS_INSTANCE_ID=${RDS_INSTANCE_ID}
+RDS_SG_NAME=${RDS_SG_NAME}
 RDS_DB_NAME=${RDS_DB_NAME}
 RDS_MASTER_USER=${RDS_MASTER_USER}
 RDS_MASTER_PASSWORD=${RDS_MASTER_PASSWORD}
@@ -78,7 +80,7 @@ cmd_create() {
         --group-id "${RDS_SG_ID}" \
         --protocol tcp --port 5432 \
         --cidr "${FIVETRAN_CIDR}" \
-        --region "${AWS_REGION}" > /dev/null
+        --region "${AWS_REGION}" > /dev/null 2>&1 || echo "  (rule already exists, skipping)"
 
     echo "Adding local IP ingress rule for seeding..."
     local my_ip
@@ -92,7 +94,7 @@ cmd_create() {
             --group-id "${RDS_SG_ID}" \
             --protocol tcp --port 5432 \
             --cidr "${my_ip}/32" \
-            --region "${AWS_REGION}" > /dev/null
+            --region "${AWS_REGION}" > /dev/null 2>&1 || echo "  (rule already exists, skipping)"
         echo "Added ingress for ${my_ip}/32"
     fi
 
@@ -229,6 +231,15 @@ cmd_destroy() {
     echo "=== Cleanup complete ==="
 }
 
+check_psql() {
+    if ! command -v psql &> /dev/null; then
+        echo "ERROR: psql not installed." >&2
+        echo "  macOS:  brew install libpq && brew link --force libpq" >&2
+        echo "  Ubuntu: sudo apt-get install -y postgresql-client" >&2
+        exit 1
+    fi
+}
+
 check_aws_auth() {
     if ! aws sts get-caller-identity --region "${AWS_REGION}" > /dev/null 2>&1; then
         echo "ERROR: Not authenticated to AWS. Run your AWS login (e.g., aws-saml.py) first." >&2
@@ -237,8 +248,8 @@ check_aws_auth() {
 }
 
 case "${1:-}" in
-    create)  check_aws_auth; cmd_create ;;
-    seed)    cmd_seed ;;
+    create)  check_psql; check_aws_auth; cmd_create ;;
+    seed)    check_psql; cmd_seed ;;
     destroy) check_aws_auth; cmd_destroy ;;
     endpoint) cmd_endpoint ;;
     *)

--- a/test/e2e/scripts/rds-lifecycle.sh
+++ b/test/e2e/scripts/rds-lifecycle.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# Manages an ephemeral RDS Postgres instance for E2E schema policy tests.
+# Usage: rds-lifecycle.sh {create|seed|destroy|endpoint}
+#
+set -euo pipefail
+
+: "${AWS_REGION:=us-west-2}"
+: "${RDS_INSTANCE_ID:=fivetran-e2e-postgres}"
+: "${RDS_DB_NAME:=fivetran_e2e}"
+: "${RDS_MASTER_USER:=e2e_admin}"
+: "${RDS_MASTER_PASSWORD:=$(openssl rand -hex 16)}"
+: "${RDS_INSTANCE_CLASS:=db.t4g.micro}"
+: "${RDS_SG_NAME:=fivetran-e2e-postgres-sg}"
+: "${FIVETRAN_CIDR:=3.239.194.48/29}"
+: "${FIVETRAN_USER_PASSWORD:=$(openssl rand -hex 16)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${SCRIPT_DIR}/.rds-state.env"
+
+save_state() {
+    cat > "${STATE_FILE}" <<EOF
+RDS_INSTANCE_ID=${RDS_INSTANCE_ID}
+RDS_DB_NAME=${RDS_DB_NAME}
+RDS_MASTER_USER=${RDS_MASTER_USER}
+RDS_MASTER_PASSWORD=${RDS_MASTER_PASSWORD}
+RDS_SG_ID=${RDS_SG_ID:-}
+RDS_ENDPOINT=${RDS_ENDPOINT:-}
+FIVETRAN_USER_PASSWORD=${FIVETRAN_USER_PASSWORD}
+EOF
+    chmod 600 "${STATE_FILE}"
+}
+
+load_state() {
+    if [[ -f "${STATE_FILE}" ]]; then
+        # shellcheck source=/dev/null
+        source "${STATE_FILE}"
+    else
+        echo "ERROR: No state file found. Run 'create' first." >&2
+        exit 1
+    fi
+}
+
+cmd_create() {
+    echo "=== Creating E2E RDS instance ==="
+
+    local vpc_id
+    vpc_id=$(aws ec2 describe-vpcs \
+        --filters "Name=isDefault,Values=true" \
+        --query "Vpcs[0].VpcId" --output text \
+        --region "${AWS_REGION}")
+
+    if [[ "${vpc_id}" == "None" || -z "${vpc_id}" ]]; then
+        echo "ERROR: No default VPC found in ${AWS_REGION}" >&2
+        exit 1
+    fi
+    echo "Using VPC: ${vpc_id}"
+
+    RDS_SG_ID=$(aws ec2 describe-security-groups \
+        --filters "Name=group-name,Values=${RDS_SG_NAME}" "Name=vpc-id,Values=${vpc_id}" \
+        --query "SecurityGroups[0].GroupId" --output text \
+        --region "${AWS_REGION}" 2>/dev/null || echo "")
+    if [[ -z "${RDS_SG_ID}" || "${RDS_SG_ID}" == "None" ]]; then
+        echo "Creating security group..."
+        RDS_SG_ID=$(aws ec2 create-security-group \
+            --group-name "${RDS_SG_NAME}" \
+            --description "Fivetran E2E test - ephemeral" \
+            --vpc-id "${vpc_id}" \
+            --query "GroupId" --output text \
+            --region "${AWS_REGION}")
+    else
+        echo "Reusing existing security group: ${RDS_SG_ID}"
+    fi
+    echo "Security group: ${RDS_SG_ID}"
+
+    echo "Adding Fivetran IP ingress rule (${FIVETRAN_CIDR})..."
+    aws ec2 authorize-security-group-ingress \
+        --group-id "${RDS_SG_ID}" \
+        --protocol tcp --port 5432 \
+        --cidr "${FIVETRAN_CIDR}" \
+        --region "${AWS_REGION}" > /dev/null
+
+    echo "Adding local IP ingress rule for seeding..."
+    local my_ip
+    my_ip=$(curl -s --retry 3 --retry-connrefused https://checkip.amazonaws.com || true)
+    if [[ -z "${my_ip}" ]]; then
+        echo "WARNING: Failed to detect local IP, skipping local ingress rule"
+    elif [[ ! "${my_ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "WARNING: Detected non-IPv4 address (${my_ip}), skipping local ingress rule"
+    else
+        aws ec2 authorize-security-group-ingress \
+            --group-id "${RDS_SG_ID}" \
+            --protocol tcp --port 5432 \
+            --cidr "${my_ip}/32" \
+            --region "${AWS_REGION}" > /dev/null
+        echo "Added ingress for ${my_ip}/32"
+    fi
+
+    echo "Creating RDS instance ${RDS_INSTANCE_ID}..."
+    aws rds create-db-instance \
+        --db-instance-identifier "${RDS_INSTANCE_ID}" \
+        --db-instance-class "${RDS_INSTANCE_CLASS}" \
+        --engine postgres \
+        --engine-version "16" \
+        --master-username "${RDS_MASTER_USER}" \
+        --master-user-password "${RDS_MASTER_PASSWORD}" \
+        --db-name "${RDS_DB_NAME}" \
+        --allocated-storage 20 \
+        --storage-type gp3 \
+        --storage-encrypted \
+        --vpc-security-group-ids "${RDS_SG_ID}" \
+        --publicly-accessible \
+        --backup-retention-period 0 \
+        --no-multi-az \
+        --tags "Key=appcode,Value=FVTR-001" "Key=purpose,Value=e2e-test" \
+        --region "${AWS_REGION}" > /dev/null
+
+    echo "Waiting for RDS to become available (this takes 5-8 minutes)..."
+    aws rds wait db-instance-available \
+        --db-instance-identifier "${RDS_INSTANCE_ID}" \
+        --region "${AWS_REGION}"
+
+    RDS_ENDPOINT=$(aws rds describe-db-instances \
+        --db-instance-identifier "${RDS_INSTANCE_ID}" \
+        --query "DBInstances[0].Endpoint.Address" --output text \
+        --region "${AWS_REGION}")
+
+    echo "RDS available at: ${RDS_ENDPOINT}"
+
+    save_state
+
+    echo ""
+    echo "=== RDS created successfully ==="
+    echo "Endpoint: ${RDS_ENDPOINT}"
+    echo "Database: ${RDS_DB_NAME}"
+    echo "Master user: ${RDS_MASTER_USER}"
+    echo "State saved to: ${STATE_FILE}"
+    echo ""
+    echo "Next: run './rds-lifecycle.sh seed' to populate the test schema"
+}
+
+cmd_seed() {
+    load_state
+    echo "=== Seeding E2E database ==="
+
+    local seed_sql="${SCRIPT_DIR}/seed.sql"
+    if [[ ! -f "${seed_sql}" ]]; then
+        echo "ERROR: seed.sql not found at ${seed_sql}" >&2
+        exit 1
+    fi
+
+    echo "Connecting to ${RDS_ENDPOINT}..."
+    PGPASSWORD="${RDS_MASTER_PASSWORD}" psql \
+        -h "${RDS_ENDPOINT}" \
+        -U "${RDS_MASTER_USER}" \
+        -d "${RDS_DB_NAME}" \
+        -v fivetran_password="${FIVETRAN_USER_PASSWORD}" \
+        -f "${seed_sql}" \
+        -q
+
+    echo ""
+    echo "=== Database seeded ==="
+    echo "Fivetran user: fivetran_e2e"
+    echo "Credentials stored in ${STATE_FILE} (not logged)"
+    echo ""
+    echo "Set env vars for E2E tests:"
+    echo "  source ${STATE_FILE}"
+    echo "  export E2E_POSTGRES_HOST=\${RDS_ENDPOINT}"
+    echo "  export E2E_POSTGRES_PASSWORD=\${FIVETRAN_USER_PASSWORD}"
+}
+
+cmd_endpoint() {
+    load_state
+    echo "${RDS_ENDPOINT}"
+}
+
+cmd_destroy() {
+    echo "=== Destroying E2E RDS instance ==="
+
+    if [[ -f "${STATE_FILE}" ]]; then
+        load_state
+    fi
+
+    if aws rds describe-db-instances \
+        --db-instance-identifier "${RDS_INSTANCE_ID}" \
+        --region "${AWS_REGION}" > /dev/null 2>&1; then
+        echo "Deleting RDS instance ${RDS_INSTANCE_ID}..."
+        aws rds delete-db-instance \
+            --db-instance-identifier "${RDS_INSTANCE_ID}" \
+            --skip-final-snapshot \
+            --delete-automated-backups \
+            --region "${AWS_REGION}" > /dev/null
+
+        echo "Waiting for RDS deletion to complete..."
+        aws rds wait db-instance-deleted \
+            --db-instance-identifier "${RDS_INSTANCE_ID}" \
+            --region "${AWS_REGION}" 2>/dev/null || true
+        echo "RDS instance deleted."
+    else
+        echo "RDS instance ${RDS_INSTANCE_ID} not found, skipping."
+    fi
+
+    local sg_id="${RDS_SG_ID:-}"
+    if [[ -z "${sg_id}" ]]; then
+        sg_id=$(aws ec2 describe-security-groups \
+            --filters "Name=group-name,Values=${RDS_SG_NAME}" \
+            --query "SecurityGroups[0].GroupId" --output text \
+            --region "${AWS_REGION}" 2>/dev/null || echo "")
+    fi
+
+    if [[ -n "${sg_id}" && "${sg_id}" != "None" ]]; then
+        echo "Deleting security group ${sg_id}..."
+        local deleted=false
+        for i in {1..6}; do
+            if aws ec2 delete-security-group --group-id "${sg_id}" --region "${AWS_REGION}" 2>/dev/null; then
+                echo "Security group deleted."
+                deleted=true
+                break
+            fi
+            echo "Security group still in use, retrying in 10 seconds... ($i/6)"
+            sleep 10
+        done
+        if [[ "${deleted}" = "false" ]]; then
+            echo "WARNING: Failed to delete security group ${sg_id} after multiple retries."
+        fi
+    fi
+
+    rm -f "${STATE_FILE}"
+    echo "=== Cleanup complete ==="
+}
+
+check_aws_auth() {
+    if ! aws sts get-caller-identity --region "${AWS_REGION}" > /dev/null 2>&1; then
+        echo "ERROR: Not authenticated to AWS. Run your AWS login (e.g., aws-saml.py) first." >&2
+        exit 1
+    fi
+}
+
+case "${1:-}" in
+    create)  check_aws_auth; cmd_create ;;
+    seed)    cmd_seed ;;
+    destroy) check_aws_auth; cmd_destroy ;;
+    endpoint) cmd_endpoint ;;
+    *)
+        echo "Usage: $0 {create|seed|destroy|endpoint}" >&2
+        echo ""
+        echo "  create   - Create RDS instance and security group"
+        echo "  seed     - Populate the database with test schema"
+        echo "  destroy  - Delete RDS instance and security group"
+        echo "  endpoint - Print the RDS endpoint"
+        exit 1
+        ;;
+esac

--- a/test/e2e/scripts/run-e2e-with-rds.sh
+++ b/test/e2e/scripts/run-e2e-with-rds.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Runs the full E2E test suite with an ephemeral RDS Postgres instance.
+# Creates the RDS, seeds it, runs tests, and destroys the RDS (always).
+#
+# Usage: ./run-e2e-with-rds.sh
+#
+# Required env vars:
+#   E2E_FIVETRAN_API_KEY, E2E_FIVETRAN_API_SECRET, E2E_FIVETRAN_GROUP_ID
+#   E2E_GOOGLE_SHEET_ID, E2E_GOOGLE_NAMED_RANGE
+#   AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up RDS (always runs) ==="
+    cd "${SCRIPT_DIR}"
+    ./rds-lifecycle.sh destroy || true
+}
+trap cleanup EXIT
+
+echo "=== Step 1: Create RDS ==="
+cd "${SCRIPT_DIR}"
+./rds-lifecycle.sh create
+
+echo ""
+echo "=== Step 2: Seed database ==="
+./rds-lifecycle.sh seed
+
+echo ""
+echo "=== Step 3: Run E2E tests ==="
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/.rds-state.env"
+export E2E_POSTGRES_HOST="${RDS_ENDPOINT}"
+export E2E_POSTGRES_PASSWORD="${FIVETRAN_USER_PASSWORD}"
+
+cd "${PROJECT_DIR}"
+make test-e2e
+
+echo ""
+echo "=== All tests passed ==="

--- a/test/e2e/scripts/seed.sql
+++ b/test/e2e/scripts/seed.sql
@@ -1,0 +1,104 @@
+-- E2E test schema for Fivetran operator schema policy tests.
+-- 3 schemas, 7 tables with primary keys and foreign keys.
+
+CREATE SCHEMA IF NOT EXISTS e2e_public;
+CREATE SCHEMA IF NOT EXISTS e2e_inventory;
+CREATE SCHEMA IF NOT EXISTS e2e_analytics;
+
+-- e2e_public: users, orders, logs
+CREATE TABLE IF NOT EXISTS e2e_public.users (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS e2e_public.orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES e2e_public.users(id),
+    total DECIMAL(10,2) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS e2e_public.logs (
+    id SERIAL PRIMARY KEY,
+    message TEXT NOT NULL,
+    level VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- e2e_inventory: products, warehouses
+CREATE TABLE IF NOT EXISTS e2e_inventory.products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    category VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS e2e_inventory.warehouses (
+    id SERIAL PRIMARY KEY,
+    location VARCHAR(100) NOT NULL,
+    capacity INTEGER NOT NULL
+);
+
+-- e2e_analytics: page_views, sessions
+CREATE TABLE IF NOT EXISTS e2e_analytics.page_views (
+    id SERIAL PRIMARY KEY,
+    url VARCHAR(255) NOT NULL,
+    user_id INTEGER NOT NULL,
+    viewed_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS e2e_analytics.sessions (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    duration INTEGER NOT NULL,
+    start_time TIMESTAMP DEFAULT NOW()
+);
+
+-- Seed minimal test data
+INSERT INTO e2e_public.users (name, email, password)
+VALUES ('test_user_1', 'test1@example.com', 'placeholder'),
+       ('test_user_2', 'test2@example.com', 'placeholder')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_public.orders (user_id, total, status)
+VALUES (1, 99.99, 'completed'),
+       (2, 49.50, 'pending')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_public.logs (message, level)
+VALUES ('test log entry', 'INFO')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_inventory.products (name, price, category)
+VALUES ('Widget A', 19.99, 'gadgets'),
+       ('Widget B', 29.99, 'gadgets')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_inventory.warehouses (location, capacity)
+VALUES ('US-West', 1000)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_analytics.page_views (url, user_id)
+VALUES ('/home', 1),
+       ('/products', 2)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO e2e_analytics.sessions (user_id, duration)
+VALUES (1, 300),
+       (2, 120)
+ON CONFLICT DO NOTHING;
+
+-- Create a read-only user for Fivetran
+DROP ROLE IF EXISTS fivetran_e2e;
+CREATE ROLE fivetran_e2e WITH LOGIN PASSWORD :'fivetran_password';
+
+GRANT USAGE ON SCHEMA e2e_public TO fivetran_e2e;
+GRANT USAGE ON SCHEMA e2e_inventory TO fivetran_e2e;
+GRANT USAGE ON SCHEMA e2e_analytics TO fivetran_e2e;
+GRANT SELECT ON ALL TABLES IN SCHEMA e2e_public TO fivetran_e2e;
+GRANT SELECT ON ALL TABLES IN SCHEMA e2e_inventory TO fivetran_e2e;
+GRANT SELECT ON ALL TABLES IN SCHEMA e2e_analytics TO fivetran_e2e;

--- a/test/e2e/testdata/google_sheets_connector.yaml.tmpl
+++ b/test/e2e/testdata/google_sheets_connector.yaml.tmpl
@@ -1,0 +1,22 @@
+apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+  annotations:
+    operator.dataverse.redhat.com/allow-deletion: "true"
+spec:
+  connector:
+    group_id: "{{.GroupID}}"
+    service: google_sheets
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: true
+    config:
+      auth_type: ServiceAccount
+      sheet_id: "{{.SheetID}}"
+      named_range: "{{.NamedRange}}"
+      schema: "{{.Schema}}"
+      table: "e2e_test_data"

--- a/test/e2e/testdata/orphan_connector.yaml.tmpl
+++ b/test/e2e/testdata/orphan_connector.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  connector:
+    group_id: "{{.GroupID}}"
+    service: fivetran_log
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: false
+    config:
+      is_account_level_connector: false
+      schema: "{{.Schema}}"

--- a/test/e2e/testdata/postgres_connector.yaml.tmpl
+++ b/test/e2e/testdata/postgres_connector.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: operator.dataverse.redhat.com/v1alpha1
+kind: FivetranConnector
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+  annotations:
+    operator.dataverse.redhat.com/allow-deletion: "true"
+spec:
+  connector:
+    group_id: "{{.GroupID}}"
+    service: postgres_rds
+    paused: true
+    schedule_type: auto
+    sync_frequency: 1440
+    daily_sync_time: "21:00"
+    run_setup_tests: true
+    config:
+      host: "{{.Host}}"
+      port: 5432
+      database: "fivetran_e2e"
+      user: "fivetran_e2e"
+      password: "vault:e2e/postgres#password"
+      schema_prefix: "{{.SchemaPrefix}}"
+      update_method: "XMIN"


### PR DESCRIPTION
Extends the E2E suite with schema policy enforcement tests using an ephemeral RDS Postgres instance created and destroyed per test run.

Schema & table policy tests:
- BLOCK_ALL: only listed schemas/tables enabled
- ALLOW_COLUMNS: listed tables enabled, unlisted disabled
- ALLOW_COLUMNS: enabled schema with no tables listed
- ALLOW_COLUMNS: disabled schema stays disabled
- ALLOW_ALL: only CR items in payload, others untouched

Column policy tests:
- BLOCK_ALL + columns: only listed columns enabled, locked PK preserved
- ALLOW_COLUMNS + columns: disable specific columns
- BLOCK_ALL + hashed column: hashed flag applied correctly
- BLOCK_ALL: no columns block means columns not managed
- BLOCK_ALL: locked column sets SchemaReady=False with error message
- validation_level NONE: schema applied without verification

Additional lifecycle tests:
- Orphan deletion: connector preserved when CR deleted without allow-deletion annotation

Infrastructure:
- rds-lifecycle.sh: create/seed/destroy ephemeral RDS with AWS auth check and no credential logging
- seed.sql: 3 schemas, 7 tables, test data, read-only Fivetran user
- CI workflow: RDS lifecycle integrated with always-destroy cleanup
- Fivetran API helpers for schema and connector state verification
- Schema hash annotation tracking for detecting reconciliation

**TO-DO**: schema reload and second pass tests (require mid-test DB mutations, planned as follow-up). Schema mismatch, syncing retry, and API timeout are unit-test-only scenarios already covered in schema_builder_test.go.